### PR TITLE
Clean and minimize codebase

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,9 +1,11 @@
+import { debug } from '../utils/logger';
+
 // API Base URL with development fallback
 export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
 
 // Log configuration in development
 if (import.meta.env.DEV) {
-  console.log('🌐 API Configuration:', {
+  debug('🌐 API Configuration:', {
     VITE_API_URL: import.meta.env.VITE_API_URL,
     VITE_USE_MOCK_API: import.meta.env.VITE_USE_MOCK_API,
     API_BASE_URL,

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,19 @@
+export const debug = (...args: unknown[]): void => {
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.debug(...args);
+  }
+};
+
+export const warn = (...args: unknown[]): void => {
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.warn(...args);
+  }
+};
+
+export const error = (...args: unknown[]): void => {
+  // Always surface errors regardless of environment
+  // eslint-disable-next-line no-console
+  console.error(...args);
+};


### PR DESCRIPTION
Introduce a centralized logging utility to remove development logs from production builds.

This refactor centralizes `console.log` calls into `debug`, `warn`, and `error` functions, allowing development-only logs to be tree-shaken out of production bundles, reducing code size and improving maintainability.