### PR TITLE
Apply iOS design tokens and modal tweaks

### DIFF
--- a/docs/ENDPOINTS_USED.md
+++ b/docs/ENDPOINTS_USED.md
@@ -1,0 +1,180 @@
+# Endpoints Usados por el Frontend
+
+Este documento describe qué endpoints de Lambda está usando el frontend y cómo se mapean a las funciones del frontend.
+
+## Endpoints Principales
+
+### 1. `/inventory` - Operaciones de Inventario
+
+#### Box Operations
+- **GET** - `consolidatedApi.inventory.box.get(params)` 
+  - Obtener información de una caja por código
+  - Usado en: `getInfoFromScannedCode()`
+  - Request: `{ resource: 'box', action: 'get', params: { codigo } }`
+
+- **CREATE** - `consolidatedApi.inventory.box.create(params)`
+  - Crear una nueva caja
+  - Usado en: `registerBox()`
+  - Request: `{ resource: 'box', action: 'create', params: { codigo, calibre, formato, empresa, ubicacion, operario } }`
+
+- **MOVE** - `consolidatedApi.inventory.box.move(params)`
+  - Mover una caja a otra ubicación
+  - Usado en: `processScan()` para cajas
+  - Request: `{ resource: 'box', action: 'move', params: { codigo, ubicacion } }`
+  - Ubicaciones válidas: `PACKING`, `BODEGA`, `VENTA`, `TRANSITO`
+
+- **UPDATE** - `consolidatedApi.inventory.box.update(params)`
+  - Actualizar una caja
+  - Disponible pero no usado actualmente en el frontend
+
+- **UNASSIGN** - `consolidatedApi.inventory.box.unassign(params)`
+  - Desasignar una caja de su pallet
+  - Disponible pero no usado actualmente en el frontend
+
+- **DELETE** - `consolidatedApi.inventory.box.delete(params)`
+  - Eliminar una caja
+  - Disponible pero no usado actualmente en el frontend
+
+#### Pallet Operations
+- **GET** - `consolidatedApi.inventory.pallet.get(params)`
+  - Obtener información de un pallet por código
+  - Usado en: `getInfoFromScannedCode()`, `getPalletDetails()`
+  - Request: `{ resource: 'pallet', action: 'get', params: { codigo } }`
+
+- **CREATE** - `consolidatedApi.inventory.pallet.create(params)`
+  - Crear un nuevo pallet
+  - Usado en: `createPallet()`
+  - Request: `{ resource: 'pallet', action: 'create', params: { codigo, maxBoxes, ubicacion } }`
+
+- **MOVE** - `consolidatedApi.inventory.pallet.move(params)`
+  - **MOVER PALLET DE TRANSITO A BODEGA** ✅
+  - Mover un pallet (y todas sus cajas) a otra ubicación
+  - Usado en: `processScan()` para pallets
+  - Request: `{ resource: 'pallet', action: 'move', params: { codigo, ubicacion } }`
+  - Ubicaciones válidas: `PACKING`, `TRANSITO`, `BODEGA`, `PREVENTA`, `VENTA`
+  - **Funcionalidad principal**: Mover pallets de TRANSITO a BODEGA está completamente implementado
+
+- **CLOSE** - `consolidatedApi.inventory.pallet.close(params)`
+  - Cerrar un pallet (prevenir adición de más cajas)
+  - Disponible pero no usado actualmente en el frontend
+
+- **UPDATE** - `consolidatedApi.inventory.pallet.update(params)`
+  - Actualizar un pallet
+  - Disponible pero no usado actualmente en el frontend
+
+- **CREATE_SINGLE_BOX_PALLET** - `consolidatedApi.inventory.pallet.createSingleBoxPallet(params)`
+  - Crear un pallet individual para una sola caja
+  - Disponible pero no usado actualmente en el frontend
+
+- **DELETE** - `consolidatedApi.inventory.pallet.delete(params)`
+  - Eliminar un pallet
+  - Disponible pero no usado actualmente en el frontend
+
+### 2. `/admin` - Operaciones Administrativas
+
+#### Issue Operations
+- **CREATE** - `consolidatedApi.admin.issue.create(params)`
+  - Crear un reporte de problema
+  - Usado en: `postIssue()`
+  - Request: `{ resource: 'issue', action: 'create', params: { descripcion, boxCode?, type?, ubicacion? } }`
+
+### 3. `/health` - Health Check
+
+- **GET** - `apiClient.get('/health')`
+  - Verificar estado del servicio
+  - Usado en: `healthCheck()`
+
+## Funciones del Frontend
+
+### Funciones Principales Usadas
+
+1. **`processScan(request: ProcessScanRequest)`**
+   - Función principal para procesar escaneos de cajas y pallets
+   - Llama a: `consolidatedApi.inventory[resource].move()`
+   - Soporta mover tanto cajas como pallets a diferentes ubicaciones
+   - **✅ Soporta mover pallets de TRANSITO a BODEGA**
+
+2. **`getInfoFromScannedCode(request: GetInfoFromScannedCodeRequest)`**
+   - Obtener información de un código escaneado (caja o pallet)
+   - Llama a: `consolidatedApi.inventory[resource].get()`
+
+3. **`postIssue(request: PostIssueRequest)`**
+   - Reportar un problema
+   - Llama a: `consolidatedApi.admin.issue.create()`
+
+4. **`registerBox(request: RegisterBoxRequest)`**
+   - Registrar una nueva caja
+   - Llama a: `consolidatedApi.inventory.box.create()`
+
+5. **`createPallet(codigo: string, maxBoxes?: number)`**
+   - Crear un nuevo pallet
+   - Llama a: `consolidatedApi.inventory.pallet.create()`
+
+6. **`getPalletDetails(codigo: string)`**
+   - Obtener detalles de un pallet incluyendo información de cajas
+   - Llama a: `consolidatedApi.inventory.pallet.get()`
+
+## Ejemplo: Mover Pallets de TRANSITO a BODEGA
+
+```typescript
+// En el componente RecibirCaja.tsx
+await processScan({
+  codigo: '12345678901234', // Código del pallet
+  ubicacion: 'BODEGA',       // Destino
+  tipo: 'PALLET'            // Opcional, se detecta automáticamente
+});
+
+// Esto llama internamente a:
+// consolidatedApi.inventory.pallet.move({
+//   codigo: '12345678901234',
+//   ubicacion: 'BODEGA'
+// })
+
+// Que envía a Lambda:
+// POST /inventory
+// {
+//   "resource": "pallet",
+//   "action": "move",
+//   "params": {
+//     "codigo": "12345678901234",
+//     "ubicacion": "BODEGA"
+//   }
+// }
+```
+
+## Validaciones
+
+### Ubicaciones Válidas para Boxes
+- `PACKING`
+- `BODEGA`
+- `VENTA`
+- `TRANSITO`
+
+### Ubicaciones Válidas para Pallets
+- `PACKING`
+- `TRANSITO`
+- `BODEGA`
+- `PREVENTA`
+- `VENTA`
+
+## Notas Importantes
+
+1. **Mover Pallets de TRANSITO a BODEGA**: ✅ **FUNCIONALIDAD COMPLETAMENTE IMPLEMENTADA**
+   - El frontend usa `processScan()` con `ubicacion: 'BODEGA'`
+   - Lambda maneja el movimiento correctamente con `MovePallet.useCase`
+   - Se mueven todas las cajas del pallet automáticamente
+
+2. **Detección Automática**: El frontend detecta automáticamente si el código es de caja o pallet basándose en la longitud del código.
+
+3. **Confirmación de Pallets**: Cuando se escanea un pallet, se muestra un modal de confirmación antes de procesar.
+
+4. **Historial**: Los escaneos se guardan en el historial del contexto `ScanContext`.
+
+## Archivos Relacionados
+
+- `src/api/endpoints.ts` - Funciones wrapper que llaman a la API consolidada
+- `src/api/consolidatedClient.ts` - Cliente API consolidado que llama a los endpoints de Lambda
+- `src/api/apiClient.ts` - Cliente HTTP base con manejo de errores y retries
+- `src/context/ScanContext.tsx` - Contexto React para manejar escaneos
+- `src/views/Scanning/RecibirCajaEnBodega/RecibirCaja.tsx` - Componente principal para recibir pallets/cajas en bodega
+

--- a/docs/ERROR_HANDLING_IMPROVEMENTS.md
+++ b/docs/ERROR_HANDLING_IMPROVEMENTS.md
@@ -152,3 +152,4 @@ Para agregar nuevas traducciones:
 - Las traducciones tienen prioridad: contexto > código de error > patrón de mensaje > mensaje original
 - Los mensajes del backend mejorados tienen prioridad sobre traducciones genéricas
 
+

--- a/docs/ERROR_HANDLING_IMPROVEMENTS.md
+++ b/docs/ERROR_HANDLING_IMPROVEMENTS.md
@@ -1,0 +1,154 @@
+# Mejoras en el Manejo de Errores
+
+Este documento describe las mejoras implementadas en el manejo de errores entre el frontend y backend para hacer los mensajes más amigables y útiles para los usuarios.
+
+## Resumen de Mejoras
+
+### 1. Sistema de Traducción de Errores (Frontend)
+
+**Archivo**: `src/utils/errorMessages.ts`
+
+- Sistema centralizado de traducción de errores técnicos a mensajes amigables en español
+- Traducciones específicas por contexto (scan, move, create)
+- Sugerencias de acción para cada tipo de error
+- Soporte para mensajes ya en español del backend
+
+**Características**:
+- Detecta automáticamente si un mensaje ya está en español y es amigable
+- Proporciona sugerencias de acción cuando es posible
+- Traduce códigos de error técnicos a mensajes claros
+
+### 2. Mensajes de Error Mejorados (Backend)
+
+#### NotFoundError
+- Mensajes específicos según el tipo de recurso (caja, tarja, cliente)
+- Mensajes en español orientados al usuario
+- Incluye el código o ID que no se encontró
+
+**Ejemplos**:
+- Antes: `Box not found: 1234567890123456`
+- Ahora: `La caja con código 1234567890123456 no fue encontrada en el sistema`
+
+#### ValidationError
+- Mensajes mejorados para validación de códigos
+- Explicaciones claras de qué está mal
+
+**Ejemplos**:
+- Antes: `Invalid box code: must be 16 digits`
+- Ahora: `El código de caja debe tener exactamente 16 dígitos. Verifica que hayas escaneado el código completo`
+
+### 3. Presentación de Errores (Backend)
+
+**Archivo**: `src/interface-adapters/presenters/ErrorPresenter.js`
+
+- Incluye información adicional en las respuestas de error:
+  - `resource`: Tipo de recurso afectado
+  - `id`: Identificador del recurso
+  - `field`: Campo específico con error (para validaciones)
+
+### 4. Visualización de Errores Mejorada (Frontend)
+
+#### ScanContext
+- Usa el sistema de traducción automáticamente
+- Almacena tanto el mensaje como la sugerencia
+- Proporciona errores más informativos
+
+#### Componentes UI
+- Muestran mensajes de error traducidos
+- Incluyen sugerencias de acción cuando están disponibles
+- Estilos mejorados para destacar sugerencias
+
+**Ejemplo visual**:
+```
+⚠️ La caja con código 1234567890123456 no fue encontrada en el sistema
+💡 El código de caja no existe en el sistema. Verifica que hayas escaneado correctamente
+```
+
+## Traducciones Implementadas
+
+### Errores de Red
+- `NETWORK_ERROR`: "Error de conexión con el servidor"
+- `TIMEOUT_ERROR`: "Tiempo de espera agotado"
+
+### Errores de Validación
+- Códigos inválidos con explicaciones claras
+- Mensajes específicos para cajas (16 dígitos) y tarjas (14 dígitos)
+
+### Errores de No Encontrado
+- Mensajes específicos para cajas y tarjas
+- Sugerencias para verificar el código
+
+### Errores de Conflicto
+- Mensajes cuando un recurso ya existe
+- Sugerencias para verificar duplicados
+
+### Errores del Servidor
+- Mensajes genéricos cuando hay errores internos
+- Sugerencias para contactar al administrador
+
+## Contextos de Operación
+
+El sistema de traducción reconoce diferentes contextos:
+
+### `scan`
+- Operaciones de escaneo de códigos
+- Mensajes específicos para códigos no encontrados o inválidos
+
+### `move`
+- Operaciones de movimiento de cajas/tarjas
+- Mensajes sobre ubicaciones inválidas o códigos no encontrados
+
+### `create`
+- Operaciones de creación
+- Mensajes sobre conflictos (códigos duplicados)
+
+## Uso en el Código
+
+### En el Frontend
+
+```typescript
+import { getUserFriendlyError, getErrorWithSuggestion } from '../utils/errorMessages';
+
+// Obtener solo el mensaje
+const errorMessage = getUserFriendlyError(error, 'scan');
+
+// Obtener mensaje con sugerencia
+const { message, suggestion } = getErrorWithSuggestion(error, 'scan');
+```
+
+### En el Backend
+
+Los errores mejorados se usan automáticamente:
+
+```javascript
+// NotFoundError ahora produce mensajes amigables
+throw new NotFoundError('Box', boxCode);
+// Resultado: "La caja con código X no fue encontrada en el sistema"
+
+// ValidationError con mensajes mejorados
+throw new ValidationError('Invalid box code: must be 16 digits');
+// Resultado: "El código de caja debe tener exactamente 16 dígitos..."
+```
+
+## Beneficios
+
+1. **Mejor Experiencia de Usuario**: Mensajes claros y en español
+2. **Acción Orientada**: Sugerencias de qué hacer cuando hay errores
+3. **Consistencia**: Todos los errores siguen el mismo formato
+4. **Mantenibilidad**: Sistema centralizado fácil de extender
+5. **Contexto Específico**: Mensajes adaptados a la operación realizada
+
+## Extensión Futura
+
+Para agregar nuevas traducciones:
+
+1. Agregar entrada en `ERROR_TRANSLATIONS` en `errorMessages.ts`
+2. Agregar traducciones específicas por contexto en `CONTEXT_ERROR_MESSAGES` si aplica
+3. Los mensajes del backend ya mejorados se usarán automáticamente
+
+## Notas Técnicas
+
+- El sistema detecta automáticamente si un mensaje ya está en español
+- Las traducciones tienen prioridad: contexto > código de error > patrón de mensaje > mensaje original
+- Los mensajes del backend mejorados tienen prioridad sobre traducciones genéricas
+

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Terminal Escaneo" />
     <meta name="description" content="Terminal para escaneo de códigos - Interfaz simple y funcional" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=SF+Pro:wght@300;400;600;700&display=swap" />
     <title>Terminal de Escaneo</title>
   </head>
   <body>

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,5 +1,6 @@
 import type { ApiResponse, ApiError, RequestConfig } from './types';
 import { API_BASE_URL } from './index';
+import { translateError } from '../utils/errorMessages';
 
 /**
  * Default configuration for API requests

--- a/src/api/consolidatedClient.ts
+++ b/src/api/consolidatedClient.ts
@@ -288,6 +288,28 @@ export const salesApi = {
     cancel: async <T = any>(params: any): Promise<ApiResponse<T>> => {
       return makeConsolidatedRequest('/sales', 'order', 'cancel', params);
     },
+
+    /**
+     * Add boxes or pallets to a DRAFT sale
+     */
+    'add-boxes': async <T = any>(params: {
+      saleId: string;
+      boxCode?: string;
+      palletCode?: string;
+    }): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/sales', 'order', 'add-boxes', params);
+    },
+
+    /**
+     * Remove boxes or pallets from a DRAFT sale
+     */
+    'remove-boxes': async <T = any>(params: {
+      saleId: string;
+      boxCode?: string;
+      palletCode?: string;
+    }): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/sales', 'order', 'remove-boxes', params);
+    },
   },
 
   /**

--- a/src/api/consolidatedClient.ts
+++ b/src/api/consolidatedClient.ts
@@ -1,0 +1,496 @@
+/**
+ * Consolidated API Client for Clean Architecture Backend
+ * 
+ * This client provides a unified interface for interacting with the 
+ * consolidated backend endpoints: /inventory, /sales, /admin
+ */
+
+import { apiClient } from './apiClient';
+import type {
+  ConsolidatedApiRequest,
+  StandardApiResponse,
+  ApiResponse,
+} from './types';
+import { API_BASE_URL } from './index';
+
+/**
+ * Response adapter that converts StandardApiResponse to ApiResponse
+ * for backward compatibility with existing code
+ * Handles both success and error responses from Lambda
+ */
+const adaptResponse = <T>(response: StandardApiResponse<T> | any): ApiResponse<T> => {
+  // If response already has success field (Lambda format with success boolean)
+  if ('success' in response && typeof response.success === 'boolean') {
+    return {
+      success: response.success,
+      data: response.data,
+      error: response.error?.message || response.error || (response.success ? undefined : response.message),
+      message: response.message,
+    };
+  }
+  
+  // If response has status field (StandardApiResponse format)
+  if ('status' in response) {
+    return {
+      success: response.status === 'success',
+      data: response.data,
+      error: response.status === 'error' || response.status === 'fail' 
+        ? (response.error?.message || response.message)
+        : undefined,
+      message: response.message,
+    };
+  }
+  
+  // Otherwise, assume success and return as-is
+  return {
+    success: true,
+    data: response.data || response,
+    message: response.message,
+  };
+};
+
+/**
+ * Makes a consolidated API request to a specific endpoint
+ * 
+ * @param endpoint - The consolidated endpoint path (/inventory, /sales, /admin)
+ * @param resource - The resource type (box, pallet, order, customer, issue, etc.)
+ * @param action - The action to perform (get, create, update, delete, etc.)
+ * @param params - Action-specific parameters
+ * @returns Promise with the adapted response
+ */
+const makeConsolidatedRequest = async <T>(
+  endpoint: '/inventory' | '/sales' | '/admin',
+  resource: string,
+  action: string,
+  params: any
+): Promise<ApiResponse<T>> => {
+  const request: ConsolidatedApiRequest = {
+    resource,
+    action,
+    params,
+  };
+
+  try {
+    // Use the existing apiClient.post which handles retries, timeouts, etc.
+    const response = await apiClient.post<T>(endpoint, request);
+    
+    // Response should already be in ApiResponse format from apiClient
+    // But we'll normalize it to ensure consistency
+    if ('success' in response && typeof response.success === 'boolean') {
+      return response as ApiResponse<T>;
+    }
+
+    // If it's a StandardApiResponse (with status field), adapt it
+    if ('status' in response || 'meta' in response) {
+      return adaptResponse(response as any as StandardApiResponse<T>);
+    }
+
+    // Otherwise, try to adapt it
+    return adaptResponse(response);
+  } catch (error) {
+    // Re-throw errors from apiClient (they're already ApiClientError)
+    throw error;
+  }
+};
+
+/**
+ * ===================================================================
+ * INVENTORY ENDPOINT METHODS
+ * ===================================================================
+ */
+
+/**
+ * Inventory API - handles all box and pallet operations
+ */
+export const inventoryApi = {
+  /**
+   * Box operations
+   */
+  box: {
+    /**
+     * Get boxes with optional filters and pagination
+     */
+    get: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'box', 'get', params);
+    },
+
+    /**
+     * Create a new box
+     */
+    create: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'box', 'create', params);
+    },
+
+    /**
+     * Update a box
+     */
+    update: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'box', 'update', params);
+    },
+
+    /**
+     * Assign a box to a pallet
+     */
+    assign: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'box', 'assign', params);
+    },
+
+    /**
+     * Unassign a box from its pallet
+     */
+    unassign: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'box', 'unassign', params);
+    },
+
+    /**
+     * Move a box to a different location
+     */
+    move: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'box', 'move', params);
+    },
+
+    /**
+     * Move box(es) between pallets
+     */
+    moveBetweenPallets: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'box', 'move-between-pallets', params);
+    },
+
+    /**
+     * Find compatible pallets for a single box
+     */
+    compatiblePallets: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'box', 'compatible-pallets', params);
+    },
+
+    /**
+     * Find compatible pallets for all unassigned boxes in a location
+     */
+    compatiblePalletsBatch: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'box', 'compatible-pallets-batch', params);
+    },
+
+    /**
+     * Delete a box
+     */
+    delete: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'box', 'delete', params);
+    },
+  },
+
+  /**
+   * Pallet operations
+   */
+  pallet: {
+    /**
+     * Get pallets with optional filters and pagination
+     */
+    get: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'pallet', 'get', params);
+    },
+
+    /**
+     * Create a new pallet
+     */
+    create: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'pallet', 'create', params);
+    },
+
+    /**
+     * Update a pallet
+     */
+    update: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'pallet', 'update', params);
+    },
+
+    /**
+     * Create a single-box pallet for a box
+     */
+    createSingleBoxPallet: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'pallet', 'create-single-box-pallet', params);
+    },
+
+    /**
+     * Close a pallet (prevent further box additions)
+     */
+    close: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'pallet', 'close', params);
+    },
+
+    /**
+     * Move a pallet to a different location
+     */
+    move: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'pallet', 'move', params);
+    },
+
+    /**
+     * Delete a pallet
+     */
+    delete: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/inventory', 'pallet', 'delete', params);
+    },
+  },
+};
+
+/**
+ * ===================================================================
+ * SALES ENDPOINT METHODS
+ * ===================================================================
+ */
+
+/**
+ * Sales API - handles orders and customers
+ */
+export const salesApi = {
+  /**
+   * Order operations
+   */
+  order: {
+    /**
+     * Get orders with optional filters and pagination
+     */
+    get: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/sales', 'order', 'get', params);
+    },
+
+    /**
+     * Create a new sales order
+     */
+    create: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/sales', 'order', 'create', params);
+    },
+
+    /**
+     * Confirm a sales order
+     */
+    confirm: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/sales', 'order', 'confirm', params);
+    },
+
+    /**
+     * Dispatch a sales order
+     */
+    dispatch: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/sales', 'order', 'dispatch', params);
+    },
+
+    /**
+     * Complete a sales order
+     */
+    complete: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/sales', 'order', 'complete', params);
+    },
+
+    /**
+     * Cancel a sales order
+     */
+    cancel: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/sales', 'order', 'cancel', params);
+    },
+  },
+
+  /**
+   * Customer operations
+   */
+  customer: {
+    /**
+     * Get customers with optional filters and pagination
+     */
+    get: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/sales', 'customer', 'get', params);
+    },
+
+    /**
+     * Create a new customer
+     */
+    create: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/sales', 'customer', 'create', params);
+    },
+
+    /**
+     * Update customer information
+     */
+    update: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/sales', 'customer', 'update', params);
+    },
+
+    /**
+     * Delete a customer
+     */
+    delete: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/sales', 'customer', 'delete', params);
+    },
+  },
+};
+
+/**
+ * ===================================================================
+ * ADMIN ENDPOINT METHODS
+ * ===================================================================
+ */
+
+/**
+ * Admin API - handles issues, reports, and configuration
+ */
+export const adminApi = {
+  /**
+   * Issue operations
+   */
+  issue: {
+    /**
+     * Get issues with optional filters and pagination
+     */
+    get: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/admin', 'issue', 'get', params);
+    },
+
+    /**
+     * Create a new issue report
+     */
+    create: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/admin', 'issue', 'create', params);
+    },
+
+    /**
+     * Update issue status
+     */
+    update: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/admin', 'issue', 'update', params);
+    },
+
+    /**
+     * Delete an issue
+     */
+    delete: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/admin', 'issue', 'delete', params);
+    },
+  },
+
+  /**
+   * Audit operations
+   */
+  audit: {
+    /**
+     * Get audit logs
+     */
+    get: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/admin', 'audit', 'get', params);
+    },
+
+    /**
+     * Perform audit on a pallet
+     */
+    create: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/admin', 'audit', 'create', params);
+    },
+  },
+
+  /**
+   * Report operations
+   */
+  report: {
+    /**
+     * Get report data
+     */
+    get: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/admin', 'report', 'get', params);
+    },
+
+    /**
+     * Generate a new report
+     */
+    generate: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/admin', 'report', 'generate', params);
+    },
+  },
+
+  /**
+   * Configuration operations
+   */
+  config: {
+    /**
+     * Get system configuration
+     */
+    get: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/admin', 'config', 'get', params);
+    },
+
+    /**
+     * Update system configuration
+     */
+    update: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/admin', 'config', 'update', params);
+    },
+  },
+
+  /**
+   * Bulk operations (dangerous!)
+   */
+  bulk: {
+    /**
+     * Delete boxes in bulk
+     */
+    deleteBoxes: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/admin', 'bulk', 'delete-boxes', params);
+    },
+
+    /**
+     * Delete pallets in bulk
+     */
+    deletePallets: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/admin', 'bulk', 'delete-pallets', params);
+    },
+
+    /**
+     * Delete all pallets and their assigned boxes
+     * ⚠️ WARNING: This is a dangerous operation!
+     */
+    deletePalletsAndBoxes: async <T = any>(params: any): Promise<ApiResponse<T>> => {
+      return makeConsolidatedRequest('/admin', 'bulk', 'delete-pallets-and-boxes', params);
+    },
+  },
+};
+
+/**
+ * ===================================================================
+ * UTILITY METHODS
+ * ===================================================================
+ */
+
+/**
+ * Health check endpoint (uses GET method)
+ */
+export const healthCheck = async (): Promise<ApiResponse<any>> => {
+  try {
+    // Health check uses GET method, not POST
+    const response = await apiClient.get<any>('/health');
+    return response;
+  } catch (error) {
+    // If error is ApiClientError, extract message
+    if (error instanceof apiClient.ApiClientError) {
+      return {
+        success: false,
+        error: error.message,
+        message: 'Service unavailable',
+      };
+    }
+    
+    return {
+      success: false,
+      error: 'Failed to reach health check endpoint',
+      message: 'Service unavailable',
+    };
+  }
+};
+
+/**
+ * Consolidated API client - single export point
+ */
+export const consolidatedApi = {
+  inventory: inventoryApi,
+  sales: salesApi,
+  admin: adminApi,
+  healthCheck,
+};
+

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1,7 +1,18 @@
+/**
+ * API Endpoints - Clean Architecture
+ * 
+ * Wrappers simplificados alrededor de la API consolidada.
+ * Mantiene las mismas firmas de funciones para compatibilidad con componentes existentes.
+ */
+
 import { apiClient } from './apiClient';
-import { validateScannedCode, validateIssueDescription } from '../utils/validators';
-import type { 
-  GetInfoFromScannedCodeRequest, 
+import { consolidatedApi } from './consolidatedClient';
+import {
+  validateScannedCode,
+  validateIssueDescription,
+} from '../utils/validators';
+import type {
+  GetInfoFromScannedCodeRequest,
   ScannedCodeInfo,
   PostIssueRequest,
   IssueReportResult,
@@ -9,19 +20,19 @@ import type {
   RegisterBoxResult,
   ProcessScanRequest,
   ProcessScanResult,
-  ApiResponse 
+  ApiResponse,
+  CreateBoxParams,
+  CreatePalletParams,
 } from './types';
 
 /**
- * Gets information from a scanned code
- * Validates the code before making the request
+ * Gets information from a scanned code (box or pallet)
  */
 export const getInfoFromScannedCode = async (
   request: GetInfoFromScannedCodeRequest
 ): Promise<ApiResponse<ScannedCodeInfo>> => {
-  // Client-side validation
   const validation = validateScannedCode(request.codigo);
-  
+
   if (!validation.isValid) {
     throw new apiClient.ApiClientError(
       validation.errorMessage || 'Código inválido',
@@ -29,41 +40,54 @@ export const getInfoFromScannedCode = async (
     );
   }
 
-  // Make the API request
-  try {
-    console.log('📡 Making API request with params:', { codigo: request.codigo.trim() });
-    console.log('📡 Full URL will be:', `${import.meta.env.VITE_API_URL}/getInfoFromScannedCode?codigo=${encodeURIComponent(request.codigo.trim())}`);
-    
-    const response = await apiClient.get<ScannedCodeInfo>(
-      '/getInfoFromScannedCode',
-      { codigo: request.codigo.trim() }
-    );
+  // Mock mode for development
+  const shouldUseMockMode = import.meta.env.VITE_USE_MOCK_API === 'true';
 
-    return response;
-  } catch (error) {
-    // Re-throw with more context if needed
-    if (error instanceof apiClient.ApiClientError) {
-      throw error;
-    }
-    
-    throw new apiClient.ApiClientError(
-      'Error al obtener información del código escaneado',
-      'REQUEST_FAILED',
-      error
-    );
+  if (shouldUseMockMode) {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    const mockResponse: ScannedCodeInfo = {
+      codigo: request.codigo.trim(),
+      tipo: validation.type === 'box' ? 'caja' : 'pallet',
+      producto: {
+        id: 'PROD-001',
+        nombre: 'Huevos Frescos',
+        descripcion: 'Huevos de gallina frescos',
+      },
+      ubicacion: {
+        almacen: 'Almacén Principal',
+        zona: 'Zona A',
+        posicion: 'A1-B2-C3',
+      },
+      estado: 'activo',
+      fechaCreacion: new Date().toISOString(),
+      ultimaActualizacion: new Date().toISOString(),
+    };
+
+    return {
+      success: true,
+      data: mockResponse,
+      message: 'Información obtenida exitosamente (modo desarrollo)',
+    };
   }
+
+  // Use consolidated API
+  const resource = validation.type === 'box' ? 'box' : 'pallet';
+  const response = await consolidatedApi.inventory[resource].get({
+    codigo: request.codigo.trim(),
+  });
+
+  return response as ApiResponse<ScannedCodeInfo>;
 };
 
 /**
- * Posts an issue report to the server
- * Validates the description before making the request
+ * Posts an issue report
  */
 export const postIssue = async (
   request: PostIssueRequest
 ): Promise<ApiResponse<IssueReportResult>> => {
-  // Client-side validation
   const validation = validateIssueDescription(request.descripcion);
-  
+
   if (!validation.isValid) {
     throw new apiClient.ApiClientError(
       validation.errorMessage || 'Descripción inválida',
@@ -71,149 +95,44 @@ export const postIssue = async (
     );
   }
 
-  // Development mode: simulate API response (also used as fallback if real API fails)
-  const shouldUseMockMode = import.meta.env.DEV && (
-    !import.meta.env.VITE_API_URL || 
-    import.meta.env.VITE_API_URL.includes('localhost') ||
-    import.meta.env.VITE_USE_MOCK_API === 'true'
-  );
+  const shouldUseMockMode = import.meta.env.VITE_USE_MOCK_API === 'true';
 
   if (shouldUseMockMode) {
-    console.log('🔧 Development Mode: Simulating postIssue API call', {
-      descripcion: request.descripcion,
-      timestamp: new Date().toISOString(),
-      reason: !import.meta.env.VITE_API_URL ? 'No API URL' : 
-              import.meta.env.VITE_API_URL.includes('localhost') ? 'Localhost URL' : 
-              'Mock mode enabled'
-    });
-
-    // Simulate network delay
     await new Promise(resolve => setTimeout(resolve, 1500));
 
-    // Simulate success response
     return {
       success: true,
       data: {
         id: `RPT-${Date.now()}`,
         mensaje: 'Reporte recibido exitosamente (modo desarrollo)',
         fechaReporte: new Date().toISOString(),
-        estado: 'recibido'
+        estado: 'recibido',
       },
-      message: 'Reporte enviado correctamente'
+      message: 'Reporte enviado correctamente',
     };
   }
 
-  // Make the API request
-  try {
-    console.log('📡 Making real API request to:', `${import.meta.env.VITE_API_URL}/postIssue`);
-    
-    const response = await apiClient.post<IssueReportResult>(
-      '/postIssue',
-      { descripcion: request.descripcion.trim() }
-    );
+  const response = await consolidatedApi.admin.issue.create({
+    descripcion: request.descripcion.trim(),
+    ...(request.boxCode && { boxCode: request.boxCode.trim() }),
+    ...(request.type && { type: request.type }),
+    ...(request.ubicacion && { ubicacion: request.ubicacion }),
+  });
 
-    console.log('✅ API Response received:', response);
-    return response;
-  } catch (error) {
-    console.error('❌ API Request failed:', error);
-    
-    // In development, if the real API fails, fall back to mock mode
-    if (import.meta.env.DEV) {
-      console.warn('🔄 Falling back to mock mode due to API failure');
-      
-      // Simulate success response as fallback
-      return {
-        success: true,
-        data: {
-          id: `RPT-FALLBACK-${Date.now()}`,
-          mensaje: 'Reporte recibido (fallback - API no disponible)',
-          fechaReporte: new Date().toISOString(),
-          estado: 'recibido'
-        },
-        message: 'Reporte enviado correctamente (modo fallback)'
-      };
-    }
-    
-    // Re-throw with more context if needed
-    if (error instanceof apiClient.ApiClientError) {
-      throw error;
-    }
-    
-    throw new apiClient.ApiClientError(
-      'Error al enviar el reporte',
-      'REQUEST_FAILED',
-      error
-    );
-  }
+  return response as ApiResponse<IssueReportResult>;
 };
 
 /**
- * Alternative method that returns only the data or throws an error
- * Useful for simpler error handling in components
- */
-export const submitIssueReport = async (descripcion: string): Promise<IssueReportResult> => {
-  const response = await postIssue({ descripcion });
-  
-  console.log('🔍 Analyzing API response in submitIssueReport:', response);
-  
-  // Handle different response formats from the API
-  // Check if response indicates success (either explicit success flag or presence of data)
-  const isSuccessful = response.success !== false && (
-    response.data || 
-    (response as any).issueNumber || 
-    (response as any).message
-  );
-  
-  if (!isSuccessful) {
-    throw new apiClient.ApiClientError(
-      response.error || 'No se pudo enviar el reporte',
-      'NO_DATA'
-    );
-  }
-  
-  // Return the appropriate data based on response structure
-  if (response.data) {
-    return response.data;
-  }
-  
-  // If data is null but we have other response fields, construct our own result
-  if ((response as any).issueNumber || (response as any).message) {
-    return {
-      id: (response as any).issueNumber || `RPT-${Date.now()}`,
-      mensaje: (response as any).message || 'Reporte enviado exitosamente',
-      fechaReporte: new Date().toISOString(),
-      estado: 'recibido'
-    };
-  }
-  
-  // Fallback
-  return {
-    mensaje: 'Reporte enviado exitosamente',
-    fechaReporte: new Date().toISOString(),
-    estado: 'recibido'
-  };
-};
-
-/**
- * Register a new box in the system
- * Validates the box code and required fields before making the request
+ * Register a new box
  */
 export const registerBox = async (
   request: RegisterBoxRequest
 ): Promise<ApiResponse<RegisterBoxResult>> => {
-  // Client-side validation
   const validation = validateScannedCode(request.codigo);
-  
-  if (!validation.isValid) {
-    throw new apiClient.ApiClientError(
-      validation.errorMessage || 'Código de caja inválido',
-      'VALIDATION_ERROR'
-    );
-  }
 
-  if (validation.type !== 'box') {
+  if (!validation.isValid || validation.type !== 'box') {
     throw new apiClient.ApiClientError(
-      'El código debe ser de una caja (15 dígitos)',
+      'El código debe ser de una caja (16 dígitos)',
       'VALIDATION_ERROR'
     );
   }
@@ -225,224 +144,120 @@ export const registerBox = async (
     );
   }
 
-  // Development mode: simulate API response
-  const shouldUseMockMode = import.meta.env.DEV && (
-    !import.meta.env.VITE_API_URL || 
-    import.meta.env.VITE_API_URL.includes('localhost') ||
-    import.meta.env.VITE_USE_MOCK_API === 'true'
-  );
+  const params: CreateBoxParams = {
+    codigo: request.codigo.trim(),
+    calibre: '01', // Default
+    formato: '1',  // Default
+    empresa: '1',  // Default
+    ubicacion: request.ubicacion || 'PACKING',
+    operario: request.producto.trim(),
+  };
 
-  if (shouldUseMockMode) {
-    console.log('🔧 Development Mode: Simulating registerBox API call', {
-      codigo: request.codigo,
-      producto: request.producto,
-      timestamp: new Date().toISOString(),
-      reason: !import.meta.env.VITE_API_URL ? 'No API URL' : 
-              import.meta.env.VITE_API_URL.includes('localhost') ? 'Localhost URL' : 
-              'Mock mode enabled'
-    });
+  const response = await consolidatedApi.inventory.box.create(params);
 
-    // Simulate network delay
-    await new Promise(resolve => setTimeout(resolve, 1500));
-
-    // Simulate success response
+  // Adapt response
+  if (response.success && response.data) {
     return {
       success: true,
       data: {
-        id: `BOX-${Date.now()}`,
+        id: (response.data as any).codigo || `BOX-${Date.now()}`,
         codigo: request.codigo.trim(),
-        mensaje: 'Caja registrada exitosamente (modo desarrollo)',
+        mensaje: response.message || 'Caja registrada exitosamente',
         fechaRegistro: new Date().toISOString(),
-        estado: 'registrado'
+        estado: 'registrado',
       },
-      message: 'Caja registrada correctamente'
+      message: response.message,
     };
   }
 
-  // Make the API request
-  try {
-    console.log('📡 Making real API request to:', `${import.meta.env.VITE_API_URL}/registerBox`);
-    
-    const response = await apiClient.post<RegisterBoxResult>(
-      '/registerBox',
-      {
-        codigo: request.codigo.trim(),
-        producto: request.producto.trim(),
-        lote: request.lote?.trim(),
-        fechaVencimiento: request.fechaVencimiento,
-        ubicacion: request.ubicacion,
-        observaciones: request.observaciones?.trim()
-      }
-    );
-
-    console.log('✅ API Response received:', response);
-    return response;
-  } catch (error) {
-    console.error('❌ API Request failed:', error);
-    
-    // In development, if the real API fails, fall back to mock mode
-    if (import.meta.env.DEV) {
-      console.warn('🔄 Falling back to mock mode due to API failure');
-      
-      // Simulate success response as fallback
-      return {
-        success: true,
-        data: {
-          id: `BOX-FALLBACK-${Date.now()}`,
-          codigo: request.codigo.trim(),
-          mensaje: 'Caja registrada (fallback - API no disponible)',
-          fechaRegistro: new Date().toISOString(),
-          estado: 'registrado'
-        },
-        message: 'Caja registrada correctamente (modo fallback)'
-      };
-    }
-    
-    // Re-throw with more context if needed
-    if (error instanceof apiClient.ApiClientError) {
-      throw error;
-    }
-    
-    throw new apiClient.ApiClientError(
-      'Error al registrar la caja',
-      'REQUEST_FAILED',
-      error
-    );
-  }
+  return response as ApiResponse<RegisterBoxResult>;
 };
 
 /**
- * Alternative method that returns only the data or throws an error
- * Useful for simpler error handling in components
+ * Process a scan (box or pallet)
  */
-export const submitBoxRegistration = async (boxData: RegisterBoxRequest): Promise<RegisterBoxResult> => {
-  const response = await registerBox(boxData);
-  
-  console.log('🔍 Analyzing API response in submitBoxRegistration:', response);
-  
-  if (!response.success || !response.data) {
-    throw new apiClient.ApiClientError(
-      response.error || 'No se pudo registrar la caja',
-      'NO_DATA'
-    );
-  }
-  
-  return response.data;
-};
+export const processScan = async (
+  request: ProcessScanRequest
+): Promise<ApiResponse<ProcessScanResult>> => {
+  const validation = validateScannedCode(request.codigo);
 
-export const processScan = async (scanData: ProcessScanRequest): Promise<ApiResponse<ProcessScanResult>> => {
-  console.log('🔍 Analyzing scan response in processScan:', scanData);
-
-  const type = scanData.codigo.length === 15 ? 'box' : 'pallet';
-  if (type === 'box') {
-    return await apiClient.post<ProcessScanResult>(
-      '/processScan',
-      scanData
-    );
-  } else if (type === 'pallet') {
-    return await apiClient.post<ProcessScanResult>(
-      '/movePallet',
-      {
-        codigo: scanData.codigo.trim(),
-        ubicacion: scanData.ubicacion.trim()
-      } 
-    );
-  } else {
+  if (!validation.isValid) {
     throw new apiClient.ApiClientError(
-      'Tipo de escaneo no válido',
+      validation.errorMessage || 'Código inválido',
       'VALIDATION_ERROR'
     );
   }
-};
-/**
- * Alternative method that returns only the data or throws an error
- * Useful for simpler error handling in components
- */
-export const submitScan = async (scanData: ProcessScanRequest): Promise<ProcessScanResult> => {
-  const response = await processScan(scanData);
-  
-  console.log('🔍 Analyzing scan response in submitScan:', response);
-  
-  if (!response.data) {
+
+  const validLocations = ['PACKING', 'BODEGA', 'VENTA', 'TRANSITO'];
+  if (!validLocations.includes(request.ubicacion)) {
     throw new apiClient.ApiClientError(
-      response.error || 'No se pudo procesar el escaneo',
-      'NO_DATA'
+      'Ubicación inválida',
+      'VALIDATION_ERROR'
     );
   }
+
+  const tipo = request.tipo || (validation.type === 'box' ? 'BOX' : 'PALLET');
+  const resource = tipo === 'BOX' ? 'box' : 'pallet';
   
-  return response.data;
+  const response = await consolidatedApi.inventory[resource].move({
+    codigo: request.codigo.trim(),
+    ubicacion: request.ubicacion,
+  });
+
+  // Adapt response
+  if (response.success) {
+    return {
+      success: true,
+      data: {
+        success: true,
+        message: response.message || 'Procesado exitosamente',
+        data: {
+          codigo: request.codigo.trim(),
+          tipo: tipo as 'BOX' | 'PALLET',
+          ubicacion: request.ubicacion,
+          estado: 'activo',
+          timestamp: new Date().toISOString(),
+        },
+      },
+      message: response.message,
+    };
+  }
+
+  return response as ApiResponse<ProcessScanResult>;
 };
 
 /**
  * Creates a new pallet
- * Validates the pallet code before making the request
  */
-export const createPallet = async (codigo: string): Promise<ApiResponse<any>> => {
-  // Client-side validation
-  const validation = validateScannedCode(codigo);
-  
-  if (!validation.isValid || validation.type !== 'pallet') {
+export const createPallet = async (
+  codigo: string,
+  maxBoxes?: number
+): Promise<ApiResponse<any>> => {
+  const base = (codigo || '').trim();
+  if (!/^\d{11}$/.test(base)) {
     throw new apiClient.ApiClientError(
-      'El código debe ser un código de pallet válido (12 dígitos)',
+      'El código base debe tener 11 dígitos',
       'VALIDATION_ERROR'
     );
   }
 
-  // Make the API request
-  try {
-    console.log('📡 Making API request to:', `${import.meta.env.VITE_API_URL}/createPallet`);
-    console.log('📤 Request payload:', { codigo: codigo.trim() });
-    
-    const response = await apiClient.post<any>(
-      '/createPallet',
-      { codigo: codigo.trim() }
-    );
+  const params: CreatePalletParams = {
+    codigo: base,
+    maxBoxes,
+  };
 
-    console.log('✅ API Response received:', response);
-    return response;
-  } catch (error) {
-    console.error('❌ API Request failed:', error);
-    
-    // Re-throw with more context if needed
-    if (error instanceof apiClient.ApiClientError) {
-      throw error;
-    }
-    
-    throw new apiClient.ApiClientError(
-      'Error al crear el pallet',
-      'REQUEST_FAILED',
-      error
-    );
-  }
+  const response = await consolidatedApi.inventory.pallet.create(params);
+  return response;
 };
 
 /**
  * Gets detailed information from a pallet including box count
- * Validates the pallet code before making the request
  */
 export const getPalletDetails = async (
   codigo: string
-): Promise<ApiResponse<{
-  codigo: string;
-  tipo: 'pallet';
-  estado: string;
-  ubicacion: string;
-  fechaCreacion: string;
-  numeroCajas: number;
-  cajas: Array<{
-    codigo: string;
-    producto: string;
-    estado: string;
-    fechaIngreso: string;
-  }>;
-  producto?: string;
-  lote?: string;
-  fechaVencimiento?: string;
-  responsable?: string;
-}>> => {
-  // Client-side validation
+): Promise<ApiResponse<any>> => {
   const validation = validateScannedCode(codigo);
-  
+
   if (!validation.isValid) {
     throw new apiClient.ApiClientError(
       validation.errorMessage || 'Código inválido',
@@ -452,29 +267,19 @@ export const getPalletDetails = async (
 
   if (validation.type !== 'pallet') {
     throw new apiClient.ApiClientError(
-      'El código debe ser de un pallet (12 dígitos)',
+      'El código debe ser de un pallet (13-14 dígitos)',
       'VALIDATION_ERROR'
     );
   }
 
-  // Development mode: simulate API response
-  const shouldUseMockMode = import.meta.env.DEV && (
-    !import.meta.env.VITE_API_URL || 
-    import.meta.env.VITE_API_URL.includes('localhost') ||
-    import.meta.env.VITE_USE_MOCK_API === 'true'
-  );
+  // Mock mode for development
+  const shouldUseMockMode = import.meta.env.VITE_USE_MOCK_API === 'true';
 
   if (shouldUseMockMode) {
-    console.log('🔧 Development Mode: Simulating getPalletDetails API call', {
-      codigo: codigo.trim(),
-      timestamp: new Date().toISOString()
-    });
-
-    // Simulate network delay
     await new Promise(resolve => setTimeout(resolve, 1500));
 
     // Generate mock data
-    const numeroCajas = Math.floor(Math.random() * 15) + 5; // Entre 5 y 20 cajas
+    const numeroCajas = Math.floor(Math.random() * 15) + 5;
     const cajas = Array.from({ length: numeroCajas }, (_, i) => ({
       codigo: `${Date.now()}${String(i).padStart(3, '0')}00`,
       producto: `Producto ${String.fromCharCode(65 + (i % 26))}`,
@@ -501,63 +306,59 @@ export const getPalletDetails = async (
     };
   }
 
-  // Make the API request
-  try {
-    console.log('📡 Making API request to:', `${import.meta.env.VITE_API_URL}/getPalletDetails`);
-    
-    const response = await apiClient.get<any>(
-      '/getPalletDetails',
-      { codigo: codigo.trim() }
-    );
+  const response = await consolidatedApi.inventory.pallet.get({
+    codigo: codigo.trim(),
+  });
 
-    console.log('✅ API Response received:', response);
-    return response;
-  } catch (error) {
-    console.error('❌ API Request failed:', error);
-    
-    // In development, if the real API fails, fall back to mock mode
-    if (import.meta.env.DEV) {
-      console.warn('🔄 Falling back to mock mode due to API failure');
-      
-      // Use the mock response above
-      const numeroCajas = Math.floor(Math.random() * 15) + 5;
-      const cajas = Array.from({ length: numeroCajas }, (_, i) => ({
-        codigo: `${Date.now()}${String(i).padStart(3, '0')}00`,
-        producto: `Producto ${String.fromCharCode(65 + (i % 26))}`,
-        estado: Math.random() > 0.1 ? 'activo' : 'dañado',
-        fechaIngreso: new Date(Date.now() - Math.random() * 7 * 24 * 60 * 60 * 1000).toISOString()
-      }));
+  return response;
+};
 
-      return {
-        success: true,
-        data: {
-          codigo: codigo.trim(),
-          tipo: 'pallet',
-          estado: 'activo',
-          ubicacion: 'BODEGA',
-          fechaCreacion: new Date(Date.now() - Math.random() * 30 * 24 * 60 * 60 * 1000).toISOString(),
-          numeroCajas,
-          cajas,
-          producto: 'Producto de prueba (fallback)',
-          lote: 'LT-' + Date.now().toString().slice(-6),
-          fechaVencimiento: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
-          responsable: 'Operador de turno'
-        },
-        message: 'Información del pallet obtenida correctamente (fallback)'
-      };
-    }
-    
-    // Re-throw with more context if needed
-    if (error instanceof apiClient.ApiClientError) {
-      throw error;
-    }
-    
+/**
+ * Simplified wrapper functions
+ */
+export const submitIssueReport = async (
+  descripcion: string
+): Promise<IssueReportResult> => {
+  const response = await postIssue({ descripcion });
+
+  if (!response.success || !response.data) {
     throw new apiClient.ApiClientError(
-      'Error al obtener información del pallet',
-      'REQUEST_FAILED',
-      error
+      response.error || 'No se pudo enviar el reporte',
+      'NO_DATA'
     );
   }
+
+  return response.data;
+};
+
+export const submitBoxRegistration = async (
+  boxData: RegisterBoxRequest
+): Promise<RegisterBoxResult> => {
+  const response = await registerBox(boxData);
+
+  if (!response.success || !response.data) {
+    throw new apiClient.ApiClientError(
+      response.error || 'No se pudo registrar la caja',
+      'NO_DATA'
+    );
+  }
+
+  return response.data;
+};
+
+export const submitScan = async (
+  scanData: ProcessScanRequest
+): Promise<ProcessScanResult> => {
+  const response = await processScan(scanData);
+
+  if (!response.success || !response.data) {
+    throw new apiClient.ApiClientError(
+      response.error || 'No se pudo procesar el escaneo',
+      'NO_DATA'
+    );
+  }
+
+  return response.data;
 };
 
 /**
@@ -573,4 +374,4 @@ export const endpoints = {
   submitScan,
   createPallet,
   getPalletDetails,
-} as const; 
+} as const;

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -362,6 +362,134 @@ export const submitScan = async (
 };
 
 /**
+ * Get confirmed sales orders (for dispatch)
+ */
+export const getConfirmedSales = async (params?: {
+  filters?: { state?: string };
+  pagination?: { limit?: number; lastKey?: string };
+}): Promise<any> => {
+  const response = await consolidatedApi.salesApi.order.get({
+    filters: { state: 'CONFIRMED', ...params?.filters },
+    pagination: params?.pagination,
+  });
+
+  if (!response.success) {
+    throw new apiClient.ApiClientError(
+      response.error || 'No se pudieron obtener las ventas',
+      'FETCH_ERROR'
+    );
+  }
+
+  return response.data;
+};
+
+/**
+ * Get sale by ID
+ */
+export const getSaleById = async (saleId: string): Promise<any> => {
+  const response = await consolidatedApi.salesApi.order.get({
+    id: saleId,
+  });
+
+  if (!response.success) {
+    throw new apiClient.ApiClientError(
+      response.error || 'No se pudo obtener la venta',
+      'FETCH_ERROR'
+    );
+  }
+
+  return response.data?.sale;
+};
+
+/**
+ * Add box to sale
+ */
+export const addBoxToSale = async (params: {
+  saleId: string;
+  boxCode: string;
+}): Promise<any> => {
+  const response = await consolidatedApi.salesApi.order['add-boxes']({
+    saleId: params.saleId,
+    boxCode: params.boxCode,
+  });
+
+  if (!response.success) {
+    throw new apiClient.ApiClientError(
+      response.error || 'No se pudo agregar la caja a la venta',
+      'ADD_BOX_ERROR'
+    );
+  }
+
+  return response.data;
+};
+
+/**
+ * Add pallet to sale
+ */
+export const addPalletToSale = async (params: {
+  saleId: string;
+  palletCode: string;
+}): Promise<any> => {
+  const response = await consolidatedApi.salesApi.order['add-boxes']({
+    saleId: params.saleId,
+    palletCode: params.palletCode,
+  });
+
+  if (!response.success) {
+    throw new apiClient.ApiClientError(
+      response.error || 'No se pudo agregar el pallet a la venta',
+      'ADD_PALLET_ERROR'
+    );
+  }
+
+  return response.data;
+};
+
+/**
+ * Remove box from sale
+ */
+export const removeBoxFromSale = async (params: {
+  saleId: string;
+  boxCode: string;
+}): Promise<any> => {
+  const response = await consolidatedApi.salesApi.order['remove-boxes']({
+    saleId: params.saleId,
+    boxCode: params.boxCode,
+  });
+
+  if (!response.success) {
+    throw new apiClient.ApiClientError(
+      response.error || 'No se pudo remover la caja de la venta',
+      'REMOVE_BOX_ERROR'
+    );
+  }
+
+  return response.data;
+};
+
+/**
+ * Remove pallet from sale
+ */
+export const removePalletFromSale = async (params: {
+  saleId: string;
+  palletCode: string;
+}): Promise<any> => {
+  const response = await consolidatedApi.salesApi.order['remove-boxes']({
+    saleId: params.saleId,
+    palletCode: params.palletCode,
+  });
+
+  if (!response.success) {
+    throw new apiClient.ApiClientError(
+      response.error || 'No se pudo remover el pallet de la venta',
+      'REMOVE_PALLET_ERROR'
+    );
+  }
+
+  return response.data;
+};
+
+/**
  * API endpoints object for easy access
  */
 export const endpoints = {
@@ -374,4 +502,10 @@ export const endpoints = {
   submitScan,
   createPallet,
   getPalletDetails,
+  getConfirmedSales,
+  getSaleById,
+  addBoxToSale,
+  addPalletToSale,
+  removeBoxFromSale,
+  removePalletFromSale,
 } as const;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,7 +1,8 @@
 import { debug } from '../utils/logger';
 
 // API Base URL with development fallback
-export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
+// Lambda API Gateway endpoints are at root level (no /api suffix)
+export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 // Log configuration in development
 if (import.meta.env.DEV) {
@@ -19,6 +20,9 @@ if (import.meta.env.DEV) {
 // API Client and Configuration
 export { apiClient, ApiClientError } from './apiClient';
 
+// NEW: Consolidated API Client (Clean Architecture)
+export { consolidatedApi, inventoryApi, salesApi, adminApi, healthCheck } from './consolidatedClient';
+
 // Types and Interfaces
 export type {
   ApiResponse,
@@ -31,6 +35,34 @@ export type {
   RegisterBoxResult,
   ProcessScanRequest,
   ProcessScanResult,
+  // NEW: Clean Architecture Types
+  ConsolidatedApiRequest,
+  StandardApiResponse,
+  PaginationParams,
+  PaginatedResponse,
+  FilterParams,
+  GetBoxesParams,
+  CreateBoxParams,
+  AssignBoxParams,
+  UpdateBoxParams,
+  MoveBoxParams,
+  MoveBoxBetweenPalletsParams,
+  CompatiblePalletsParams,
+  CompatiblePalletsBatchParams,
+  GetPalletsParams,
+  CreatePalletParams,
+  UpdatePalletParams,
+  CreateSingleBoxPalletParams,
+  ClosePalletParams,
+  MovePalletParams,
+  GetOrdersParams,
+  CreateOrderParams,
+  GetCustomersParams,
+  CreateCustomerParams,
+  GetIssuesParams,
+  CreateIssueParams,
+  UpdateIssueParams,
+  GenerateReportParams,
 } from './types';
 
 // Endpoints
@@ -40,7 +72,9 @@ export {
   registerBox,
   submitBoxRegistration,
   processScan,
-  submitScan
+  submitScan,
+  createPallet,
+  getPalletDetails,
 } from './endpoints';
 
 // Utilities (re-export for convenience)

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -370,11 +370,17 @@ export interface GetOrdersParams {
 
 /**
  * Order resource - Create action params
+ * Supports two formats:
+ * 1. Legacy: items with palletId/palletCode and boxIds (specific boxes from pallets)
+ * 2. New: items with calibre and quantity (auto-select boxes by calibre from BODEGA)
  */
 export interface CreateOrderParams {
   customerId: string;
   type: 'Venta' | 'Reposición' | 'Donación' | 'Inutilizado' | 'Ración';
-  items: Array<{ palletCode: string }>;
+  items: Array<
+    | { palletId?: string; palletCode?: string; boxIds: string[] } // Legacy format
+    | { calibre: string; quantity: number } // New format: auto-select by calibre
+  >;
   notes?: string;
   metadata?: Record<string, any>;
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -71,6 +71,9 @@ export interface CodeValidationResult {
  */
 export interface PostIssueRequest {
   descripcion: string;
+  boxCode?: string;
+  type?: 'DEFECT' | 'DAMAGE' | 'OTHER';
+  ubicacion?: string;
 }
 
 /**
@@ -135,4 +138,321 @@ export interface ProcessScanResult {
     timestamp: string;
     [key: string]: any;
   };
+}
+
+/**
+ * ===================================================================
+ * NEW CLEAN ARCHITECTURE TYPES
+ * ===================================================================
+ */
+
+/**
+ * Consolidated API Request format for Clean Architecture backend
+ */
+export interface ConsolidatedApiRequest<P = any> {
+  resource: string; // e.g., 'box', 'pallet', 'order', 'customer', 'issue'
+  action: string; // e.g., 'get', 'create', 'update', 'delete', 'move', 'close'
+  params: P;
+}
+
+/**
+ * Standardized API Response from Clean Architecture backend
+ */
+export interface StandardApiResponse<T = any> {
+  status: 'success' | 'fail' | 'error';
+  message: string;
+  data?: T;
+  meta: {
+    requestId: string;
+    timestamp: string;
+    [key: string]: any;
+  };
+}
+
+/**
+ * Pagination parameters for list queries
+ */
+export interface PaginationParams {
+  limit?: number;
+  lastKey?: string;
+}
+
+/**
+ * Paginated response wrapper
+ */
+export interface PaginatedResponse<T> {
+  items: T[];
+  count: number;
+  nextKey?: string | null;
+}
+
+/**
+ * Filter options for queries
+ */
+export interface FilterParams {
+  calibre?: string;
+  formato?: string;
+  empresa?: string;
+  horario?: string;
+  codigoPrefix?: string;
+  [key: string]: any;
+}
+
+/**
+ * ===================================================================
+ * INVENTORY RESOURCE TYPES
+ * ===================================================================
+ */
+
+/**
+ * Box resource - Get action params
+ */
+export interface GetBoxesParams {
+  ubicacion?: 'PACKING' | 'BODEGA' | 'TRANSITO' | 'PREVENTA' | 'VENTA' | 'UNSUBSCRIBED';
+  filters?: FilterParams;
+  pagination?: PaginationParams;
+  codigo?: string; // For getting single box by code
+}
+
+/**
+ * Box resource - Create action params
+ */
+export interface CreateBoxParams {
+  codigo: string;
+  calibre: string;
+  formato: string;
+  empresa: string;
+  ubicacion: string;
+  operario?: string;
+  horario?: string;
+  customInfo?: string;
+}
+
+/**
+ * Box resource - Assign action params
+ */
+export interface AssignBoxParams {
+  boxCode: string;
+  palletCode: string;
+}
+
+/**
+ * Box resource - Update action params
+ */
+export interface UpdateBoxParams {
+  codigo: string;
+  updates: Partial<{
+    calibre: string;
+    formato: string;
+    empresa: string;
+    ubicacion: string;
+    operario: string;
+    horario: string;
+    customInfo: string;
+  }>;
+}
+
+/**
+ * Box resource - Move action params
+ */
+export interface MoveBoxParams {
+  codigo: string;
+  ubicacion: string;
+}
+
+/**
+ * Box resource - Move between pallets params
+ */
+export interface MoveBoxBetweenPalletsParams {
+  boxCode?: string;
+  codigo?: string;
+  boxCodes?: string[]; // For batch mode
+  palletCode: string;
+  destinationPalletCode?: string;
+}
+
+/**
+ * Box resource - Compatible pallets params
+ */
+export interface CompatiblePalletsParams {
+  codigo?: string;
+  boxCode?: string;
+  ubicacion?: string;
+  autoAssign?: boolean;
+}
+
+/**
+ * Box resource - Compatible pallets batch params
+ */
+export interface CompatiblePalletsBatchParams {
+  ubicacion: string;
+  filters?: FilterParams;
+}
+
+/**
+ * Pallet resource - Get action params
+ */
+export interface GetPalletsParams {
+  estado?: 'open' | 'closed' | 'dismantled';
+  ubicacion?: string;
+  pagination?: PaginationParams;
+  codigo?: string; // For getting single pallet by code
+}
+
+/**
+ * Pallet resource - Create action params
+ */
+export interface CreatePalletParams {
+  codigo: string; // Base code (11 digits)
+  ubicacion?: string;
+  maxBoxes?: number;
+  calibre?: string;
+  formato?: string;
+  empresa?: string;
+}
+
+/**
+ * Pallet resource - Close action params
+ */
+export interface ClosePalletParams {
+  codigo: string;
+}
+
+/**
+ * Pallet resource - Update action params
+ */
+export interface UpdatePalletParams {
+  codigo: string;
+  updates: Partial<{
+    ubicacion: string;
+    maxBoxes: number;
+    calibre: string;
+    formato: string;
+    empresa: string;
+  }>;
+}
+
+/**
+ * Pallet resource - Create single box pallet params
+ */
+export interface CreateSingleBoxPalletParams {
+  boxCode: string;
+  ubicacion?: string;
+}
+
+/**
+ * Pallet resource - Move action params
+ */
+export interface MovePalletParams {
+  codigo: string;
+  ubicacion: string;
+}
+
+/**
+ * ===================================================================
+ * SALES RESOURCE TYPES
+ * ===================================================================
+ */
+
+/**
+ * Order resource - Get action params
+ */
+export interface GetOrdersParams {
+  filters?: {
+    state?: 'DRAFT' | 'CONFIRMED' | 'DISPATCHED' | 'COMPLETED' | 'CANCELLED';
+    customerId?: string;
+    startDate?: string;
+    endDate?: string;
+  };
+  pagination?: PaginationParams;
+  id?: string; // For getting single order by ID
+}
+
+/**
+ * Order resource - Create action params
+ */
+export interface CreateOrderParams {
+  customerId: string;
+  type: 'Venta' | 'Reposición' | 'Donación' | 'Inutilizado' | 'Ración';
+  items: Array<{ palletCode: string }>;
+  notes?: string;
+  metadata?: Record<string, any>;
+}
+
+/**
+ * Customer resource - Get action params
+ */
+export interface GetCustomersParams {
+  filters?: {
+    status?: 'ACTIVE' | 'INACTIVE' | 'DELETED';
+    search?: string;
+  };
+  pagination?: PaginationParams;
+  id?: string; // For getting single customer by ID
+}
+
+/**
+ * Customer resource - Create action params
+ */
+export interface CreateCustomerParams {
+  name: string;
+  email?: string;
+  phone?: string;
+  address?: string;
+  taxId?: string;
+  contactPerson?: string;
+  metadata?: Record<string, any>;
+}
+
+/**
+ * ===================================================================
+ * ADMIN RESOURCE TYPES
+ * ===================================================================
+ */
+
+/**
+ * Issue resource - Get action params
+ */
+export interface GetIssuesParams {
+  filters?: {
+    status?: 'PENDING' | 'IN_PROGRESS' | 'RESOLVED';
+    ubicacion?: string;
+    startDate?: string;
+    endDate?: string;
+  };
+  pagination?: PaginationParams;
+  id?: string; // For getting single issue by ID
+}
+
+/**
+ * Issue resource - Create action params
+ */
+export interface CreateIssueParams {
+  descripcion: string;
+  boxCode?: string;
+  type?: 'DEFECT' | 'DAMAGE' | 'OTHER';
+  ubicacion?: string;
+}
+
+/**
+ * Issue resource - Update action params
+ */
+export interface UpdateIssueParams {
+  issueId: string;
+  status: 'PENDING' | 'IN_PROGRESS' | 'RESOLVED';
+  resolution?: string;
+}
+
+/**
+ * Report resource - Generate action params
+ */
+export interface GenerateReportParams {
+  type: 'inventory' | 'sales' | 'audit' | 'daily-production';
+  filters?: {
+    startDate?: string;
+    endDate?: string;
+    ubicacion?: string;
+    date?: string;
+  };
+  format?: 'excel' | 'json';
 } 

--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -4,8 +4,8 @@
   bottom: 0;
   left: 0;
   right: 0;
-  background-color: #ffffff;
-  border-top: 1px solid #e1e5e9;
+  background-color: var(--background-white);
+  border-top: 1px solid var(--color-border);
   z-index: 100;
 }
 
@@ -26,26 +26,26 @@
   background: none;
   border: none;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: opacity 0.15s ease;
   min-height: 60px;
-  color: #6c757d;
+  color: var(--text-secondary);
   font-family: inherit;
   text-decoration: none;
   position: relative;
 }
 
 .nav-tab:hover {
-  background-color: #f6f8fa;
-  color: #2c2c2c;
+  background-color: var(--background-light-gray);
+  color: var(--text-primary);
 }
 
 .nav-tab:active {
-  background-color: #eaeef2;
+  opacity: 0.6;
 }
 
 .nav-tab.active {
-  color: #0969da;
-  background-color: #f1f8ff;
+  color: var(--color-accent);
+  background-color: var(--background-light-gray);
 }
 
 .nav-tab.active::after {
@@ -55,7 +55,7 @@
   left: 0;
   right: 0;
   height: 2px;
-  background-color: #0969da;
+  background-color: var(--color-accent);
 }
 
 .nav-icon {
@@ -97,64 +97,64 @@
 
 /* Focus styles for accessibility */
 .nav-tab:focus-visible {
-  outline: 2px solid #0969da;
+  outline: 2px solid var(--color-accent);
   outline-offset: -2px;
 }
 
 /* Dark mode support */
 .dark-theme .footer {
-  background-color: #21262d;
-  border-top-color: #30363d;
+  background-color: var(--background-dark);
+  border-top-color: var(--border-dark);
 }
 
 .dark-theme .nav-tab {
-  color: #8b949e;
+  color: var(--text-light);
 }
 
 .dark-theme .nav-tab:hover {
-  background-color: #30363d;
-  color: #e6edf3;
+  background-color: var(--background-medium-gray);
+  color: var(--text-primary);
 }
 
 .dark-theme .nav-tab:active {
-  background-color: #262c36;
+  background-color: var(--background-darkest);
 }
 
 .dark-theme .nav-tab.active {
-  color: #2f81f7;
-  background-color: #0d2b52;
+  color: var(--color-accent);
+  background-color: var(--background-medium-gray);
 }
 
 .dark-theme .nav-tab.active::after {
-  background-color: #2f81f7;
+  background-color: var(--color-accent);
 }
 
 /* Fallback for prefers-color-scheme */
 @media (prefers-color-scheme: light) {
   .footer {
-    background-color: #f4f5f6;
-    border-top-color: #30363d;
+    background-color: var(--background-white);
+    border-top-color: var(--color-border);
   }
-  
+
   .nav-tab {
-    color: #8b949e;
+    color: var(--text-secondary);
   }
-  
+
   .nav-tab:hover {
-    background-color: #30363d;
-    color: #e6edf3;
+    background-color: var(--background-light-gray);
+    color: var(--text-primary);
   }
-  
+
   .nav-tab:active {
-    background-color: #262c365f;
+    opacity: 0.6;
   }
-  
+
   .nav-tab.active {
-    color: #152030;
-    background-color: #0d2b5279;
+    color: var(--color-accent);
+    background-color: var(--background-light-gray);
   }
-  
+
   .nav-tab.active::after {
-    background-color: #2f81f7;
+    background-color: var(--color-accent);
   }
-} 
+}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import './Footer.css';
+import { Button } from '../ui';
 
 interface NavTab {
   id: string;
@@ -22,7 +23,7 @@ const Footer: React.FC<FooterProps> = ({ tabs, onTabClick }) => {
     <footer className="footer">
       <nav className="footer-nav">
         {tabs.map((tab) => (
-          <button
+          <Button
             key={tab.id}
             className={`nav-tab ${tab.isActive ? 'active' : ''}`}
             onClick={() => handleTabClick(tab.id)}
@@ -33,7 +34,7 @@ const Footer: React.FC<FooterProps> = ({ tabs, onTabClick }) => {
               {tab.icon}
             </span>
             <span className="nav-label">{tab.label}</span>
-          </button>
+          </Button>
         ))}
       </nav>
     </footer>

--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -10,15 +10,19 @@
 }
 
 .layout-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1.5rem;
-  background-color: var(--background-white);
-  border-bottom: 1px solid var(--border-light);
-  position: sticky;
+  position: fixed;
   top: 0;
-  z-index: 50;
+  left: 0;
+  right: 0;
+  height: var(--nav-height);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--spacing-md);
+  background-color: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(20px);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  z-index: 100;
 }
 
 .header-info {
@@ -55,21 +59,18 @@
 
 .layout-content {
   flex: 1;
-  padding: 2rem 1.5rem;
+  padding: calc(var(--spacing-lg) + var(--nav-height)) var(--spacing-md) var(--spacing-lg);
   max-width: 600px;
   margin: 0 auto;
   width: 100%;
-  padding-bottom: 6rem; /* Space for fixed footer */
+  padding-bottom: calc(6rem + var(--nav-height));
   box-sizing: border-box;
 }
 
 /* Responsive design */
 @media (max-width: 768px) {
   .layout-header {
-    padding: 1rem;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1rem;
+    padding: 0 var(--spacing-md);
   }
   
   .status-indicator {
@@ -87,7 +88,7 @@
 
 @media (max-width: 480px) {
   .layout-header {
-    padding: 0.75rem;
+    padding: 0 var(--spacing-sm);
   }
   
   .header-title {

--- a/src/components/PalletConfirmationModal/PalletConfirmationModal.css
+++ b/src/components/PalletConfirmationModal/PalletConfirmationModal.css
@@ -1,7 +1,7 @@
 .pallet-modal-container {
-  background: white;
-  border-radius: 16px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  background: var(--background-white);
+  border-radius: var(--modal-radius);
+  box-shadow: 0 20px 60px var(--shadow-dark);
   max-width: 700px;
   width: 90%;
   max-height: 90vh;
@@ -9,9 +9,9 @@
 }
 
 .pallet-modal-header {
-  background: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
-  color: white;
-  padding: 24px;
+  background: var(--color-accent);
+  color: var(--background-white);
+  padding: var(--spacing-md);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -26,21 +26,20 @@
 .pallet-modal-close {
   background: rgba(255, 255, 255, 0.2);
   border: none;
-  color: white;
+  color: var(--background-white);
   width: 36px;
   height: 36px;
   border-radius: 50%;
   font-size: 18px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: opacity 0.2s ease;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .pallet-modal-close:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.3);
-  transform: scale(1.1);
+  opacity: 0.7;
 }
 
 .pallet-modal-close:disabled {
@@ -49,7 +48,7 @@
 }
 
 .pallet-modal-content {
-  padding: 32px;
+  padding: var(--spacing-lg);
   max-height: calc(90vh - 120px);
   overflow-y: auto;
 }
@@ -62,8 +61,8 @@
 .loading-spinner {
   width: 40px;
   height: 40px;
-  border: 4px solid #f3f3f3;
-  border-top: 4px solid #3498db;
+  border: 4px solid var(--border-dark);
+  border-top: 4px solid var(--color-accent);
   border-radius: 50%;
   animation: spin 1s linear infinite;
   margin: 0 auto 16px;
@@ -75,7 +74,7 @@
 }
 
 .pallet-loading p {
-  color: #666;
+  color: var(--text-secondary);
   font-size: 16px;
   margin: 0;
 }
@@ -83,7 +82,7 @@
 .pallet-error {
   text-align: center;
   padding: 40px 20px;
-  color: #e74c3c;
+  color: var(--color-accent);
 }
 
 .pallet-error .error-icon {
@@ -98,20 +97,19 @@
 }
 
 .retry-btn {
-  background: #3498db;
-  color: white;
+  background: var(--color-accent);
+  color: var(--background-white);
   border: none;
   padding: 12px 24px;
-  border-radius: 8px;
+  border-radius: var(--corner-radius);
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: opacity 0.2s ease;
 }
 
 .retry-btn:hover {
-  background: #2980b9;
-  transform: translateY(-2px);
+  opacity: 0.8;
 }
 
 .pallet-details {
@@ -124,15 +122,15 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px;
-  background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
-  border-radius: 12px;
-  border-left: 5px solid #3498db;
+  padding: var(--spacing-md);
+  background: var(--background-light-gray);
+  border-radius: var(--corner-radius);
+  border-left: 4px solid var(--color-accent);
 }
 
 .pallet-code {
   font-size: 18px;
-  color: #2c3e50;
+  color: var(--text-primary);
 }
 
 .pallet-status {
@@ -185,10 +183,10 @@
 }
 
 .cajas-summary {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-  border-radius: 12px;
-  padding: 24px;
+  background: var(--color-accent);
+  color: var(--background-white);
+  border-radius: var(--corner-radius);
+  padding: var(--spacing-md);
   text-align: center;
 }
 
@@ -237,10 +235,10 @@
 
 .confirmation-question {
   text-align: center;
-  padding: 24px;
+  padding: var(--spacing-md);
   background: #fff3cd;
   border: 2px solid #ffc107;
-  border-radius: 12px;
+  border-radius: var(--corner-radius);
 }
 
 .confirmation-question h3 {
@@ -263,21 +261,20 @@
 }
 
 .confirm-btn {
-  background: linear-gradient(135deg, #28a745 0%, #20c997 100%);
-  color: white;
+  background: var(--color-accent);
+  color: var(--background-white);
   border: none;
-  padding: 16px 24px;
-  border-radius: 12px;
+  padding: var(--spacing-md);
+  border-radius: var(--corner-radius);
   font-size: 16px;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s ease;
-  box-shadow: 0 4px 12px rgba(40, 167, 69, 0.3);
+  transition: opacity 0.2s ease;
+  box-shadow: 0 4px 12px var(--shadow-medium);
 }
 
 .confirm-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(40, 167, 69, 0.4);
+  opacity: 0.8;
 }
 
 .issue-buttons {
@@ -287,15 +284,15 @@
 }
 
 .issue-btn {
-  background: #fff;
-  border: 2px solid #dee2e6;
-  color: #495057;
+  background: var(--background-white);
+  border: 2px solid var(--color-border);
+  color: var(--text-primary);
   padding: 12px 16px;
-  border-radius: 8px;
+  border-radius: var(--corner-radius);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: opacity 0.2s ease;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -304,32 +301,31 @@
 }
 
 .issue-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  opacity: 0.8;
 }
 
 .issue-btn.count-issue:hover {
-  border-color: #dc3545;
-  color: #dc3545;
-  background: #f8f9fa;
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background: var(--background-light-gray);
 }
 
 .issue-btn.damage-issue:hover {
-  border-color: #fd7e14;
-  color: #fd7e14;
-  background: #f8f9fa;
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background: var(--background-light-gray);
 }
 
 .issue-btn.product-issue:hover {
-  border-color: #6f42c1;
-  color: #6f42c1;
-  background: #f8f9fa;
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background: var(--background-light-gray);
 }
 
 .issue-btn.other-issue:hover {
-  border-color: #6c757d;
-  color: #6c757d;
-  background: #f8f9fa;
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background: var(--background-light-gray);
 }
 
 /* Responsive Design */

--- a/src/components/PalletConfirmationModal/PalletConfirmationModal.css
+++ b/src/components/PalletConfirmationModal/PalletConfirmationModal.css
@@ -1,17 +1,3 @@
-.pallet-modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.7);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  backdrop-filter: blur(4px);
-}
-
 .pallet-modal-container {
   background: white;
   border-radius: 16px;
@@ -20,18 +6,6 @@
   width: 90%;
   max-height: 90vh;
   overflow: hidden;
-  animation: modalSlideIn 0.3s ease-out;
-}
-
-@keyframes modalSlideIn {
-  from {
-    transform: translateY(-20px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
 }
 
 .pallet-modal-header {

--- a/src/components/PalletConfirmationModal/PalletConfirmationModal.tsx
+++ b/src/components/PalletConfirmationModal/PalletConfirmationModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { getPalletDetails } from '../../api/endpoints';
 import './PalletConfirmationModal.css';
+import { Modal, Button } from '../ui';
 
 interface PalletDetails {
   codigo: string;
@@ -83,11 +84,6 @@ const PalletConfirmationModal: React.FC<PalletConfirmationModalProps> = ({
     onClose();
   };
 
-  const handleOverlayClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
-      handleClose();
-    }
-  };
 
   const formatDate = (dateString: string) => {
     try {
@@ -108,17 +104,18 @@ const PalletConfirmationModal: React.FC<PalletConfirmationModalProps> = ({
   if (!isOpen) return null;
 
   return (
-    <div className="pallet-modal-overlay" onClick={handleOverlayClick}>
+    <Modal isOpen={isOpen} onClose={handleClose}>
       <div className="pallet-modal-container">
         <div className="pallet-modal-header">
           <h2>📦 Confirmación de Pallet</h2>
-          <button 
+          <Button
             className="pallet-modal-close"
             onClick={handleClose}
             disabled={loading}
+            aria-label="Cerrar"
           >
             ✕
-          </button>
+          </Button>
         </div>
 
         <div className="pallet-modal-content">
@@ -213,48 +210,48 @@ const PalletConfirmationModal: React.FC<PalletConfirmationModalProps> = ({
               </div>
 
               <div className="pallet-actions">
-                <button 
+                <Button
                   onClick={handleConfirm}
                   className="confirm-btn"
                 >
                   ✅ Sí, confirmo {palletDetails.numeroCajas} cajas
-                </button>
-                
+                </Button>
+
                 <div className="issue-buttons">
-                  <button 
+                  <Button
                     onClick={() => handleReportIssue('Número de cajas no coincide')}
                     className="issue-btn count-issue"
                   >
                     📊 El número no coincide
-                  </button>
-                  
-                  <button 
+                  </Button>
+
+                  <Button
                     onClick={() => handleReportIssue('Cajas dañadas')}
                     className="issue-btn damage-issue"
                   >
                     📦 Cajas dañadas
-                  </button>
-                  
-                  <button 
+                  </Button>
+
+                  <Button
                     onClick={() => handleReportIssue('Producto incorrecto')}
                     className="issue-btn product-issue"
                   >
                     🏷️ Producto incorrecto
-                  </button>
-                  
-                  <button 
+                  </Button>
+
+                  <Button
                     onClick={() => handleReportIssue('Otro problema operacional')}
                     className="issue-btn other-issue"
                   >
                     ❓ Otro problema
-                  </button>
+                  </Button>
                 </div>
               </div>
             </div>
           )}
         </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/components/PalletConfirmationModal/PalletConfirmationModal.tsx
+++ b/src/components/PalletConfirmationModal/PalletConfirmationModal.tsx
@@ -130,9 +130,9 @@ const PalletConfirmationModal: React.FC<PalletConfirmationModalProps> = ({
             <div className="pallet-error">
               <span className="error-icon">⚠️</span>
               <p>{error}</p>
-              <button onClick={fetchPalletDetails} className="retry-btn">
+              <Button onClick={fetchPalletDetails} className="retry-btn">
                 Reintentar
-              </button>
+              </Button>
             </div>
           )}
 

--- a/src/components/ReportIssueModal/ReportIssueModal.css
+++ b/src/components/ReportIssueModal/ReportIssueModal.css
@@ -1,28 +1,39 @@
 /* ReportIssueModal Styles */
 .modal-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.6);
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.3);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
-  padding: 1rem;
-  backdrop-filter: blur(2px);
+  padding: var(--spacing-md);
+  backdrop-filter: blur(8px);
+  animation: fadeIn 0.3s ease;
 }
 
 .modal-container {
-  background-color: #ffffff;
-  border-radius: 12px;
+  background-color: var(--background-white);
+  border-radius: 16px;
   max-width: 600px;
   width: 100%;
   max-height: 90vh;
   overflow-y: auto;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  box-shadow: 0 4px 10px var(--shadow-medium);
   position: relative;
+  transform: scale(0.95);
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.modal-overlay.open .modal-container {
+  transform: scale(1);
+  opacity: 1;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 /* Modal Header */
@@ -50,17 +61,16 @@
   background: none;
   border: none;
   font-size: 1.5rem;
-  color: #6c757d;
+  color: var(--color-accent);
   cursor: pointer;
-  padding: 0.5rem;
-  border-radius: 6px;
-  transition: all 0.15s ease;
+  padding: var(--spacing-sm);
+  border-radius: var(--corner-radius);
+  transition: opacity 0.2s ease;
   line-height: 1;
 }
 
 .modal-close-btn:hover:not(:disabled) {
-  background-color: #e9ecef;
-  color: #2c2c2c;
+  opacity: 0.7;
 }
 
 .modal-close-btn:disabled {

--- a/src/components/ReportIssueModal/ReportIssueModal.css
+++ b/src/components/ReportIssueModal/ReportIssueModal.css
@@ -15,17 +15,17 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1.5rem 2rem;
-  border-bottom: 1px solid #e1e5e9;
-  background-color: #f8f9fa;
-  border-radius: 12px 12px 0 0;
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-bottom: 1px solid var(--color-border);
+  background-color: var(--background-light-gray);
+  border-radius: var(--modal-radius) var(--modal-radius) 0 0;
 }
 
 .modal-title {
   font-size: 1.375rem;
   font-weight: 600;
   margin: 0;
-  color: #2c2c2c;
+  color: var(--text-primary);
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -106,9 +106,9 @@
 }
 
 .issue-type-btn {
-  background-color: #ffffff;
-  border: 2px solid #e1e5e9;
-  border-radius: 8px;
+  background-color: var(--background-white);
+  border: 2px solid var(--color-border);
+  border-radius: var(--corner-radius);
   padding: 1rem;
   cursor: pointer;
   transition: all 0.15s ease;
@@ -121,15 +121,14 @@
 }
 
 .issue-type-btn:hover:not(:disabled) {
-  border-color: #0969da;
-  background-color: #f6f8fa;
-  transform: translateY(-1px);
+  border-color: var(--color-accent);
+  background-color: var(--background-light-gray);
 }
 
 .issue-type-btn.active {
-  border-color: #0969da;
+  border-color: var(--color-accent);
   background-color: #dbeafe;
-  color: #1e40af;
+  color: var(--color-accent);
 }
 
 .issue-type-btn:disabled {
@@ -155,9 +154,9 @@
 }
 
 .priority-btn {
-  background-color: #ffffff;
-  border: 2px solid #e1e5e9;
-  border-radius: 8px;
+  background-color: var(--background-white);
+  border: 2px solid var(--color-border);
+  border-radius: var(--corner-radius);
   padding: 1rem 0.75rem;
   cursor: pointer;
   transition: all 0.15s ease;
@@ -170,8 +169,7 @@
 }
 
 .priority-btn:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  opacity: 0.8;
 }
 
 .priority-btn:disabled {

--- a/src/components/ReportIssueModal/ReportIssueModal.css
+++ b/src/components/ReportIssueModal/ReportIssueModal.css
@@ -1,17 +1,4 @@
 /* ReportIssueModal Styles */
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background-color: rgba(0, 0, 0, 0.3);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: var(--spacing-md);
-  backdrop-filter: blur(8px);
-  animation: fadeIn 0.3s ease;
-}
-
 .modal-container {
   background-color: var(--background-white);
   border-radius: 16px;
@@ -21,19 +8,6 @@
   overflow-y: auto;
   box-shadow: 0 4px 10px var(--shadow-medium);
   position: relative;
-  transform: scale(0.95);
-  opacity: 0;
-  transition: transform 0.3s ease, opacity 0.3s ease;
-}
-
-.modal-overlay.open .modal-container {
-  transform: scale(1);
-  opacity: 1;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
 }
 
 /* Modal Header */
@@ -386,10 +360,6 @@
 
 /* Responsive Design */
 @media (max-width: 768px) {
-  .modal-overlay {
-    padding: 0.5rem;
-  }
-  
   .modal-container {
     max-height: 95vh;
   }
@@ -435,11 +405,6 @@
 }
 
 @media (max-width: 480px) {
-  .modal-overlay {
-    padding: 0;
-    align-items: stretch;
-  }
-  
   .modal-container {
     border-radius: 0;
     max-height: 100vh;

--- a/src/components/ReportIssueModal/ReportIssueModal.tsx
+++ b/src/components/ReportIssueModal/ReportIssueModal.tsx
@@ -191,7 +191,7 @@ Reportado el: ${new Date().toLocaleString('es-ES')}
               <label className="form-label">Tipo de Problema</label>
               <div className="issue-types-grid">
                 {issueTypes.map(type => (
-                  <button
+                  <Button
                     key={type.value}
                     type="button"
                     className={`issue-type-btn ${formData.type === type.value ? 'active' : ''}`}
@@ -200,7 +200,7 @@ Reportado el: ${new Date().toLocaleString('es-ES')}
                   >
                     <span className="issue-icon">{type.icon}</span>
                     <span className="issue-label">{type.label}</span>
-                  </button>
+                  </Button>
                 ))}
               </div>
             </div>
@@ -209,7 +209,7 @@ Reportado el: ${new Date().toLocaleString('es-ES')}
               <label className="form-label">Prioridad</label>
               <div className="priority-grid">
                 {priorityLevels.map(priority => (
-                  <button
+                  <Button
                     key={priority.value}
                     type="button"
                     className={`priority-btn ${formData.priority === priority.value ? 'active' : ''}`}
@@ -224,7 +224,7 @@ Reportado el: ${new Date().toLocaleString('es-ES')}
                       {priority.label}
                     </span>
                     <span className="priority-description">{priority.description}</span>
-                  </button>
+                  </Button>
                 ))}
               </div>
             </div>

--- a/src/components/ReportIssueModal/ReportIssueModal.tsx
+++ b/src/components/ReportIssueModal/ReportIssueModal.tsx
@@ -3,6 +3,7 @@ import { useScannedCodeContext } from '../../context/ScannedCodeContext';
 import { submitIssueReport } from '../../api/endpoints';
 import { validateIssueDescription } from '../../utils/validators';
 import './ReportIssueModal.css';
+import { Modal, Button } from '../ui';
 
 interface ReportIssueModalProps {
   isOpen: boolean;
@@ -153,26 +154,22 @@ Reportado el: ${new Date().toLocaleString('es-ES')}
     }
   };
 
-  const handleOverlayClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
-      handleClose();
-    }
-  };
 
   if (!isOpen) return null;
 
   return (
-    <div className="modal-overlay" onClick={handleOverlayClick}>
+    <Modal isOpen={isOpen} onClose={handleClose}>
       <div className="modal-container">
         <div className="modal-header">
           <h2 className="modal-title">🚨 Reportar Problema</h2>
-          <button 
+          <Button
             className="modal-close-btn"
             onClick={handleClose}
             disabled={isSubmitting}
+            aria-label="Cerrar"
           >
             ✕
-          </button>
+          </Button>
         </div>
 
         {submitSuccess ? (
@@ -279,15 +276,15 @@ Reportado el: ${new Date().toLocaleString('es-ES')}
             </div>
 
             <div className="modal-actions">
-              <button
+              <Button
                 type="button"
                 className="cancel-btn"
                 onClick={handleClose}
                 disabled={isSubmitting}
               >
                 Cancelar
-              </button>
-              <button
+              </Button>
+              <Button
                 type="submit"
                 className="submit-btn"
                 disabled={isSubmitting || !formData.description.trim()}
@@ -300,12 +297,12 @@ Reportado el: ${new Date().toLocaleString('es-ES')}
                 ) : (
                   'Enviar Reporte'
                 )}
-              </button>
+              </Button>
             </div>
           </form>
         )}
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/components/ui/Button.module.css
+++ b/src/components/ui/Button.module.css
@@ -1,0 +1,22 @@
+.button {
+  min-height: var(--touch-size);
+  min-width: var(--touch-size);
+  padding: 0 1rem;
+  border-radius: var(--corner-radius);
+  border: 1px solid var(--input-border);
+  background-color: var(--background-white);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.button:not(:disabled):active {
+  opacity: 0.7;
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styles from './Button.module.css';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+}
+
+const Button: React.FC<ButtonProps> = ({ children, ...rest }) => (
+  <button className={styles.button} {...rest}>
+    {children}
+  </button>
+);
+
+export default Button;

--- a/src/components/ui/Modal.module.css
+++ b/src/components/ui/Modal.module.css
@@ -1,0 +1,29 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(8px);
+  padding: var(--spacing-md);
+}
+
+.container {
+  background-color: var(--background-white);
+  border-radius: var(--modal-radius);
+  width: 100%;
+  max-width: 600px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 4px 10px var(--shadow-medium);
+  transform: scale(0.96);
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.open .container {
+  transform: scale(1);
+  opacity: 1;
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styles from './Modal.module.css';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
+  if (!isOpen) return null;
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div className={`${styles.overlay} ${styles.open}`} onClick={handleOverlayClick}>
+      <div className={styles.container}>{children}</div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,2 @@
+export { default as Button } from './Button';
+export { default as Modal } from './Modal';

--- a/src/index.css
+++ b/src/index.css
@@ -121,6 +121,9 @@ input, select, textarea {
   font-family: inherit;
   font-size: 0.875rem;
   color: var(--text-primary);
+  ::placeholder {
+    color: var(--placeholder-gray);
+  }
   min-height: var(--touch-size);
   transition: border-color 0.15s ease;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,12 @@
-@import './styles/industrial-theme.css';
+@import './styles/designSystem.css';
 
 :root {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
   color-scheme: light;
-  color: var(--text-primary);
-  background-color: var(--background-light-gray);
+  color: var(--color-text);
+  background-color: var(--color-surface);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -86,8 +85,8 @@ button {
   color: var(--text-primary);
   cursor: pointer;
   transition: all 0.15s ease;
-  min-height: 44px;
-  min-width: 44px;
+  min-height: var(--touch-size);
+  min-width: var(--touch-size);
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -122,7 +121,7 @@ input, select, textarea {
   font-family: inherit;
   font-size: 0.875rem;
   color: var(--text-primary);
-  min-height: 44px;
+  min-height: var(--touch-size);
   transition: border-color 0.15s ease;
 }
 

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -7,6 +7,8 @@ import Historial from '../views/Historial';
 import RegistrarCaja from '../views/Scanning/RecibirCajaEnBodega/RecibirCaja';
 import ConsultarCodigo from '../views/Scanning/ConsultarCodigo/ConsultarCodigo';
 import CrearPallet from '../views/Scanning/CreatePalletForm/CreatePalletForm';
+import DespacharVenta from '../views/DespacharVenta/DespacharVenta';
+import EscanearVenta from '../views/EscanearVenta/EscanearVenta';
 
 const AppRoutes: React.FC = () => {
   return (
@@ -33,6 +35,12 @@ const AppRoutes: React.FC = () => {
 
           {/* Crear pallet route */}
           <Route path="/crear-pallet" element={<CrearPallet />} />
+
+          {/* Despachar venta route */}
+          <Route path="/despachar-venta" element={<DespacharVenta />} />
+
+          {/* Escanear venta route */}
+          <Route path="/escanear-venta/:saleId" element={<EscanearVenta />} />
           
           {/* Future routes can be added here */}
           {/* <Route path="/scanner" element={<Scanner />} /> */}

--- a/src/styles/designSystem.css
+++ b/src/styles/designSystem.css
@@ -1,0 +1,45 @@
+@font-face {
+  font-family: 'SF Pro';
+  src: url('/fonts/SF-Pro.woff2') format('woff2');
+  font-weight: 300 900;
+  font-display: swap;
+}
+
+:root {
+  --font-base: 'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --color-bg: #ffffff;
+  --color-surface: #f2f2f7;
+  --color-accent: #007aff;
+  --color-text: #1c1c1e;
+  --spacing-sm: 8px;
+  --spacing-md: 16px;
+  --spacing-lg: 24px;
+  --corner-radius: 8px;
+  --touch-size: 44px;
+  --nav-height: 44px;
+  --modal-radius: 16px;
+
+  /* aliases for existing styles */
+  --text-primary: var(--color-text);
+  --background-white: var(--color-bg);
+  --background-light-gray: var(--color-surface);
+  --btn-primary-bg: var(--color-accent);
+  --input-border: #d0d5dd;
+  --btn-secondary-bg: #f0f0f0;
+  --border-dark: #c7c7cc;
+  --industrial-primary: var(--color-accent);
+  --industrial-primary-dark: #0057d9;
+  --industrial-success: #34c759;
+  --input-bg: var(--color-bg);
+  --input-focus-border: var(--color-accent);
+  --shadow-light: rgba(0,0,0,0.05);
+  --shadow-medium: rgba(0,0,0,0.1);
+  --shadow-dark: rgba(0,0,0,0.2);
+  --shadow-focus: rgba(0,122,255,0.2);
+}
+
+body {
+  font-family: var(--font-base);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}

--- a/src/styles/designSystem.css
+++ b/src/styles/designSystem.css
@@ -11,6 +11,9 @@
   --color-surface: #f2f2f7;
   --color-accent: #007aff;
   --color-text: #1c1c1e;
+  --color-border: #c7c7cc;
+  --color-placeholder: #8e8e93;
+  --text-secondary: #3c3c43;
   --spacing-sm: 8px;
   --spacing-md: 16px;
   --spacing-lg: 24px;
@@ -23,10 +26,11 @@
   --text-primary: var(--color-text);
   --background-white: var(--color-bg);
   --background-light-gray: var(--color-surface);
+  --placeholder-gray: var(--color-placeholder);
   --btn-primary-bg: var(--color-accent);
-  --input-border: #d0d5dd;
+  --input-border: var(--color-border);
   --btn-secondary-bg: #f0f0f0;
-  --border-dark: #c7c7cc;
+  --border-dark: var(--color-border);
   --industrial-primary: var(--color-accent);
   --industrial-primary-dark: #0057d9;
   --industrial-success: #34c759;

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -1,0 +1,281 @@
+/**
+ * Error Message Translation System
+ * Translates technical error codes and messages into user-friendly Spanish messages
+ * with actionable suggestions when possible
+ */
+
+interface ErrorTranslation {
+  message: string;
+  suggestion?: string;
+  userFriendly?: boolean;
+}
+
+/**
+ * Common error patterns that need translation
+ */
+const ERROR_TRANSLATIONS: Record<string, ErrorTranslation> = {
+  // Network Errors
+  NETWORK_ERROR: {
+    message: 'Error de conexión con el servidor',
+    suggestion: 'Verifica tu conexión a internet e intenta nuevamente',
+  },
+  TIMEOUT_ERROR: {
+    message: 'Tiempo de espera agotado',
+    suggestion: 'La petición tardó demasiado. Intenta nuevamente',
+  },
+  
+  // Validation Errors
+  VALIDATION_ERROR: {
+    message: 'Error de validación',
+    suggestion: 'Verifica que los datos ingresados sean correctos',
+  },
+  'Box code must be 16 digits': {
+    message: 'El código de caja debe tener 16 dígitos',
+    suggestion: 'Verifica que hayas escaneado correctamente el código',
+  },
+  'Invalid box code: must be 16 digits': {
+    message: 'Código de caja inválido: debe tener 16 dígitos',
+    suggestion: 'Asegúrate de escanear el código completo',
+  },
+  'Invalid pallet code: must be 14 digits': {
+    message: 'Código de pallet inválido: debe tener 14 dígitos',
+    suggestion: 'Asegúrate de escanear el código completo de la tarja',
+  },
+  
+  // Not Found Errors
+  NOT_FOUND: {
+    message: 'No encontrado',
+    suggestion: 'Verifica que el código sea correcto',
+  },
+  'Box not found': {
+    message: 'Caja no encontrada',
+    suggestion: 'El código de caja no existe en el sistema. Verifica que hayas escaneado correctamente',
+  },
+  'Pallet not found': {
+    message: 'Tarja no encontrada',
+    suggestion: 'El código de tarja no existe en el sistema. Verifica que hayas escaneado correctamente',
+  },
+  'no fue encontrada': {
+    message: 'El código no fue encontrado en el sistema',
+    suggestion: 'Verifica que el código escaneado sea correcto. Si es una caja nueva, asegúrate de registrarla primero',
+  },
+  'no fue encontrado': {
+    message: 'El código no fue encontrado en el sistema',
+    suggestion: 'Verifica que el código escaneado sea correcto',
+  },
+  
+  // Conflict Errors
+  CONFLICT: {
+    message: 'Conflicto en la operación',
+    suggestion: 'El recurso ya existe o fue modificado. Intenta actualizar la página',
+  },
+  'Box with code': {
+    message: 'La caja ya existe en el sistema',
+    suggestion: 'Esta caja ya fue registrada anteriormente',
+  },
+  
+  // Location/Operation Errors
+  'Invalid location': {
+    message: 'Ubicación inválida',
+    suggestion: 'Verifica que la ubicación sea correcta',
+  },
+  'Cannot move': {
+    message: 'No se puede mover',
+    suggestion: 'La operación de movimiento no es válida para este estado',
+  },
+  
+  // Server Errors
+  INTERNAL_ERROR: {
+    message: 'Error interno del servidor',
+    suggestion: 'Ocurrió un error inesperado. Si el problema persiste, contacta al administrador',
+  },
+  
+  // DynamoDB Errors
+  'ResourceNotFoundException': {
+    message: 'Recurso no encontrado',
+    suggestion: 'El recurso solicitado no existe en la base de datos',
+  },
+  'ConditionalCheckFailedException': {
+    message: 'La operación falló porque el recurso fue modificado',
+    suggestion: 'Intenta actualizar la página y vuelve a intentar',
+  },
+  'ThrottlingException': {
+    message: 'El servicio está temporalmente sobrecargado',
+    suggestion: 'Espera unos segundos e intenta nuevamente',
+  },
+};
+
+/**
+ * Context-specific error translations
+ * Provides more specific messages based on the operation context
+ */
+const CONTEXT_ERROR_MESSAGES: Record<string, Record<string, ErrorTranslation>> = {
+  scan: {
+    'NOT_FOUND': {
+      message: 'Código no encontrado',
+      suggestion: 'El código escaneado no existe en el sistema. Verifica que sea correcto',
+    },
+    'VALIDATION_ERROR': {
+      message: 'Código inválido',
+      suggestion: 'El formato del código no es válido. Debe ser de 12 dígitos (tarja) o 16 dígitos (caja)',
+    },
+  },
+  move: {
+    'NOT_FOUND': {
+      message: 'No se puede mover: el código no existe',
+      suggestion: 'Verifica que el código sea correcto antes de intentar moverlo',
+    },
+    'VALIDATION_ERROR': {
+      message: 'No se puede mover: ubicación inválida',
+      suggestion: 'Verifica que la ubicación de destino sea válida',
+    },
+  },
+  create: {
+    'CONFLICT': {
+      message: 'El código ya existe',
+      suggestion: 'Este código ya fue registrado anteriormente. Verifica que no sea un duplicado',
+    },
+    'VALIDATION_ERROR': {
+      message: 'Datos inválidos',
+      suggestion: 'Revisa que todos los campos requeridos estén completos y sean válidos',
+    },
+  },
+};
+
+/**
+ * Translates an error message to a user-friendly version
+ * @param error - Error object or message string
+ * @param context - Operation context (scan, move, create, etc.)
+ * @returns User-friendly error message with suggestion
+ */
+export function translateError(
+  error: Error | string | unknown,
+  context?: string
+): { message: string; suggestion?: string } {
+  let errorMessage = '';
+  let errorCode = '';
+  
+  // Extract error message and code
+  if (error instanceof Error) {
+    errorMessage = error.message;
+    errorCode = (error as any).code || '';
+  } else if (typeof error === 'string') {
+    errorMessage = error;
+  } else if (error && typeof error === 'object') {
+    errorMessage = (error as any).message || (error as any).error?.message || '';
+    errorCode = (error as any).code || (error as any).error?.code || '';
+  }
+  
+  // First, try context-specific translations
+  if (context && CONTEXT_ERROR_MESSAGES[context]) {
+    const contextTranslations = CONTEXT_ERROR_MESSAGES[context];
+    
+    // Try error code first
+    if (errorCode && contextTranslations[errorCode]) {
+      const translation = contextTranslations[errorCode];
+      return {
+        message: translation.message,
+        suggestion: translation.suggestion,
+      };
+    }
+    
+    // Then try matching message patterns
+    for (const [pattern, translation] of Object.entries(contextTranslations)) {
+      if (errorMessage.includes(pattern) || errorMessage === pattern) {
+        return {
+          message: translation.message,
+          suggestion: translation.suggestion,
+        };
+      }
+    }
+  }
+  
+  // Try general error code translations
+  if (errorCode && ERROR_TRANSLATIONS[errorCode]) {
+    const translation = ERROR_TRANSLATIONS[errorCode];
+    return {
+      message: translation.message,
+      suggestion: translation.suggestion,
+    };
+  }
+  
+  // Try to match message patterns
+  for (const [pattern, translation] of Object.entries(ERROR_TRANSLATIONS)) {
+    if (errorMessage.includes(pattern) || errorMessage === pattern) {
+      return {
+        message: translation.message,
+        suggestion: translation.suggestion,
+      };
+    }
+  }
+  
+  // Default: return original message if no translation found
+  // But make it slightly more user-friendly
+  if (errorMessage) {
+    // Check if message is already in Spanish and user-friendly (from backend improvements)
+    const isSpanishMessage = /[áéíóúñüÁÉÍÓÚÑÜ]/.test(errorMessage);
+    const isTechnicalMessage = errorMessage.includes('Exception') || 
+                                errorMessage.includes('Error:') ||
+                                errorMessage.includes('code:') ||
+                                errorMessage.startsWith('Error ');
+    
+    // If message is already in Spanish and not technical, use it directly
+    if (isSpanishMessage && !isTechnicalMessage) {
+      return {
+        message: errorMessage,
+        suggestion: 'Si el problema persiste, contacta al administrador',
+      };
+    }
+    
+    // Remove technical prefixes
+    let friendlyMessage = errorMessage
+      .replace(/^Error \d+: /, '')
+      .replace(/^\[.*?\] /, '')
+      .replace(/Error:/g, '')
+      .trim();
+    
+    // If it's still very technical, add a generic prefix
+    if (friendlyMessage.includes('Exception') || friendlyMessage.includes('Error:')) {
+      friendlyMessage = `Error: ${friendlyMessage}`;
+    }
+    
+    return {
+      message: friendlyMessage,
+      suggestion: 'Si el problema persiste, contacta al administrador',
+    };
+  }
+  
+  // Ultimate fallback
+  return {
+    message: 'Ocurrió un error inesperado',
+    suggestion: 'Por favor intenta nuevamente o contacta al administrador si el problema persiste',
+  };
+}
+
+/**
+ * Gets a user-friendly error message for display in UI
+ * @param error - Error object or message
+ * @param context - Operation context
+ * @returns Formatted error message string
+ */
+export function getUserFriendlyError(
+  error: Error | string | unknown,
+  context?: string
+): string {
+  const { message } = translateError(error, context);
+  return message;
+}
+
+/**
+ * Gets error message with suggestion for display
+ * @param error - Error object or message
+ * @param context - Operation context
+ * @returns Object with message and optional suggestion
+ */
+export function getErrorWithSuggestion(
+  error: Error | string | unknown,
+  context?: string
+): { message: string; suggestion?: string } {
+  return translateError(error, context);
+}
+

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -12,6 +12,8 @@ interface ErrorTranslation {
 
 /**
  * Common error patterns that need translation
+ * Sincronizado con el catálogo de códigos del backend
+ * Nota: Las sugerencias del backend tienen prioridad sobre estas
  */
 const ERROR_TRANSLATIONS: Record<string, ErrorTranslation> = {
   // Network Errors
@@ -23,11 +25,51 @@ const ERROR_TRANSLATIONS: Record<string, ErrorTranslation> = {
     message: 'Tiempo de espera agotado',
     suggestion: 'La petición tardó demasiado. Intenta nuevamente',
   },
+  PARSE_ERROR: {
+    message: 'Error al procesar la respuesta del servidor',
+    suggestion: 'Intenta nuevamente. Si el problema persiste, contacta al administrador',
+  },
   
   // Validation Errors
   VALIDATION_ERROR: {
     message: 'Error de validación',
     suggestion: 'Verifica que los datos ingresados sean correctos',
+  },
+  INVALID_BOX_CODE: {
+    message: 'El código de caja debe tener exactamente 16 dígitos',
+    suggestion: 'Verifica que hayas escaneado el código completo',
+  },
+  INVALID_PALLET_CODE: {
+    message: 'El código de tarja debe tener exactamente 14 dígitos',
+    suggestion: 'Verifica que hayas escaneado el código completo',
+  },
+  INVALID_LOCATION: {
+    message: 'La ubicación proporcionada no es válida',
+    suggestion: 'Verifica que la ubicación sea correcta',
+  },
+  INVALID_CALIBRE: {
+    message: 'El calibre no coincide con lo solicitado',
+    suggestion: 'El calibre de la caja/pallet no está en los calibres solicitados para esta venta',
+  },
+  BOX_COUNT_EXCEEDED: {
+    message: 'Excede la cantidad de cajas solicitadas',
+    suggestion: 'Has escaneado más cajas de las solicitadas para este calibre. Remueve algunas cajas',
+  },
+  EGGS_EXCEEDED: {
+    message: 'Excede la cantidad de huevos permitida',
+    suggestion: 'La cantidad de huevos excede el límite permitido',
+  },
+  EGGS_INCOMPLETE: {
+    message: 'Faltan cajas para completar la venta',
+    suggestion: 'Aún faltan cajas por escanear. Continúa escaneando hasta completar todas las cajas solicitadas',
+  },
+  NO_REQUESTED_CALIBRES: {
+    message: 'Esta venta no tiene calibres solicitados',
+    suggestion: 'Esta venta no se puede despachar porque no tiene calibres definidos',
+  },
+  SALE_NOT_DRAFT: {
+    message: 'La venta no se puede modificar',
+    suggestion: 'Solo se pueden modificar ventas en borrador (DRAFT). Esta venta ya fue confirmada',
   },
   'Box code must be 16 digits': {
     message: 'El código de caja debe tener 16 dígitos',
@@ -46,6 +88,30 @@ const ERROR_TRANSLATIONS: Record<string, ErrorTranslation> = {
   NOT_FOUND: {
     message: 'No encontrado',
     suggestion: 'Verifica que el código sea correcto',
+  },
+  BOX_NOT_FOUND: {
+    message: 'La caja no fue encontrada en el sistema',
+    suggestion: 'El código de caja no existe en el sistema. Verifica que hayas escaneado correctamente',
+  },
+  PALLET_NOT_FOUND: {
+    message: 'La tarja no fue encontrada en el sistema',
+    suggestion: 'El código de tarja no existe en el sistema. Verifica que hayas escaneado correctamente',
+  },
+  CUSTOMER_NOT_FOUND: {
+    message: 'El cliente no fue encontrado',
+    suggestion: 'El cliente con el ID proporcionado no existe en el sistema',
+  },
+  SALE_NOT_FOUND: {
+    message: 'La venta no fue encontrada',
+    suggestion: 'La venta con el ID proporcionado no existe en el sistema',
+  },
+  BOX_NOT_IN_SALE: {
+    message: 'La caja no está en esta venta',
+    suggestion: 'Esta caja no está en la venta actual. Verifica el código',
+  },
+  PALLET_NOT_IN_SALE: {
+    message: 'El pallet no está en esta venta',
+    suggestion: 'Este pallet no está en la venta actual. Verifica el código',
   },
   'Box not found': {
     message: 'Caja no encontrada',
@@ -69,6 +135,34 @@ const ERROR_TRANSLATIONS: Record<string, ErrorTranslation> = {
     message: 'Conflicto en la operación',
     suggestion: 'El recurso ya existe o fue modificado. Intenta actualizar la página',
   },
+  BOX_ALREADY_EXISTS: {
+    message: 'La caja ya existe en el sistema',
+    suggestion: 'Esta caja ya fue registrada anteriormente',
+  },
+  BOX_ALREADY_IN_SALE: {
+    message: 'La caja ya está en esta venta',
+    suggestion: 'Esta caja ya fue agregada. Verifica que no hayas escaneado el mismo código dos veces',
+  },
+  PALLET_ALREADY_IN_SALE: {
+    message: 'El pallet ya está en esta venta',
+    suggestion: 'Este pallet ya fue agregado. Verifica que no hayas escaneado el mismo código dos veces',
+  },
+  CUSTOMER_ALREADY_EXISTS: {
+    message: 'El cliente ya existe en el sistema',
+    suggestion: 'Ya existe un cliente con el email proporcionado',
+  },
+  BOX_NOT_IN_BODEGA: {
+    message: 'La caja no está en BODEGA',
+    suggestion: 'Solo se pueden agregar cajas que estén en BODEGA. Verifica la ubicación de la caja',
+  },
+  PALLET_NOT_IN_BODEGA: {
+    message: 'El pallet no está en BODEGA',
+    suggestion: 'Solo se pueden agregar pallets que estén en BODEGA. Verifica la ubicación del pallet',
+  },
+  PALLET_NO_BOXES_IN_BODEGA: {
+    message: 'El pallet no tiene cajas en BODEGA',
+    suggestion: 'El pallet no tiene cajas disponibles en BODEGA para agregar a la venta',
+  },
   'Box with code': {
     message: 'La caja ya existe en el sistema',
     suggestion: 'Esta caja ya fue registrada anteriormente',
@@ -88,6 +182,24 @@ const ERROR_TRANSLATIONS: Record<string, ErrorTranslation> = {
   INTERNAL_ERROR: {
     message: 'Error interno del servidor',
     suggestion: 'Ocurrió un error inesperado. Si el problema persiste, contacta al administrador',
+  },
+  DATABASE_ERROR: {
+    message: 'Error de base de datos',
+    suggestion: 'Error al acceder a la base de datos. Intenta nuevamente en unos momentos',
+  },
+  SERVICE_UNAVAILABLE: {
+    message: 'Servicio no disponible',
+    suggestion: 'El servicio está temporalmente no disponible. Intenta nuevamente más tarde',
+  },
+  
+  // Rate Limit Errors
+  RATE_LIMIT_EXCEEDED: {
+    message: 'Demasiadas solicitudes',
+    suggestion: 'Has excedido el límite de solicitudes. Por favor, espera unos momentos e intenta nuevamente',
+  },
+  THROTTLING_ERROR: {
+    message: 'Servicio temporalmente sobrecargado',
+    suggestion: 'El servicio está temporalmente sobrecargado. Por favor, intente nuevamente',
   },
   
   // DynamoDB Errors
@@ -140,6 +252,56 @@ const CONTEXT_ERROR_MESSAGES: Record<string, Record<string, ErrorTranslation>> =
       suggestion: 'Revisa que todos los campos requeridos estén completos y sean válidos',
     },
   },
+  dispatch: {
+    'SALE_NOT_DRAFT': {
+      message: 'La venta no se puede modificar',
+      suggestion: 'Solo se pueden modificar ventas en borrador (DRAFT). Esta venta ya fue confirmada.',
+    },
+    'NO_REQUESTED_CALIBRES': {
+      message: 'Esta venta no tiene calibres solicitados',
+      suggestion: 'Esta venta no se puede despachar porque no tiene calibres definidos.',
+    },
+    'BOX_ALREADY_IN_SALE': {
+      message: 'La caja ya está en esta venta',
+      suggestion: 'Esta caja ya fue agregada. Verifica que no hayas escaneado el mismo código dos veces.',
+    },
+    'PALLET_ALREADY_IN_SALE': {
+      message: 'El pallet ya está en esta venta',
+      suggestion: 'Este pallet ya fue agregado. Verifica que no hayas escaneado el mismo código dos veces.',
+    },
+    'BOX_NOT_IN_BODEGA': {
+      message: 'La caja no está en BODEGA',
+      suggestion: 'Solo se pueden agregar cajas que estén en BODEGA. Verifica la ubicación de la caja.',
+    },
+    'PALLET_NOT_IN_BODEGA': {
+      message: 'El pallet no está en BODEGA',
+      suggestion: 'Solo se pueden agregar pallets que estén en BODEGA. Verifica la ubicación del pallet.',
+    },
+    'PALLET_NO_BOXES_IN_BODEGA': {
+      message: 'El pallet no tiene cajas en BODEGA',
+      suggestion: 'El pallet no tiene cajas disponibles en BODEGA para agregar a la venta.',
+    },
+    'INVALID_CALIBRE': {
+      message: 'El calibre no coincide con lo solicitado',
+      suggestion: 'El calibre de la caja/pallet no está en los calibres solicitados para esta venta.',
+    },
+    'BOX_COUNT_EXCEEDED': {
+      message: 'Excede la cantidad de cajas solicitadas',
+      suggestion: 'Has escaneado más cajas de las solicitadas para este calibre. Remueve algunas cajas.',
+    },
+    'EGGS_INCOMPLETE': {
+      message: 'Faltan cajas para completar la venta',
+      suggestion: 'Aún faltan cajas por escanear. Continúa escaneando hasta completar todas las cajas solicitadas.',
+    },
+    'BOX_NOT_IN_SALE': {
+      message: 'La caja no está en esta venta',
+      suggestion: 'Esta caja no está en la venta actual. Verifica el código.',
+    },
+    'PALLET_NOT_IN_SALE': {
+      message: 'El pallet no está en esta venta',
+      suggestion: 'Este pallet no está en la venta actual. Verifica el código.',
+    },
+  },
 };
 
 /**
@@ -154,16 +316,23 @@ export function translateError(
 ): { message: string; suggestion?: string } {
   let errorMessage = '';
   let errorCode = '';
+  let backendSuggestion: string | undefined;
   
   // Extract error message and code
   if (error instanceof Error) {
     errorMessage = error.message;
     errorCode = (error as any).code || '';
+    // Extract suggestion from error details if available (from ApiClientError)
+    if ((error as any).details) {
+      backendSuggestion = (error as any).details.suggestion;
+    }
   } else if (typeof error === 'string') {
     errorMessage = error;
   } else if (error && typeof error === 'object') {
     errorMessage = (error as any).message || (error as any).error?.message || '';
     errorCode = (error as any).code || (error as any).error?.code || '';
+    // Extract suggestion from error object (new unified format)
+    backendSuggestion = (error as any).suggestion || (error as any).error?.suggestion || (error as any).details?.suggestion;
   }
   
   // First, try context-specific translations
@@ -175,7 +344,8 @@ export function translateError(
       const translation = contextTranslations[errorCode];
       return {
         message: translation.message,
-        suggestion: translation.suggestion,
+        // Priorizar sugerencia del backend sobre la local
+        suggestion: backendSuggestion || translation.suggestion,
       };
     }
     
@@ -184,7 +354,8 @@ export function translateError(
       if (errorMessage.includes(pattern) || errorMessage === pattern) {
         return {
           message: translation.message,
-          suggestion: translation.suggestion,
+          // Priorizar sugerencia del backend sobre la local
+          suggestion: backendSuggestion || translation.suggestion,
         };
       }
     }
@@ -195,7 +366,8 @@ export function translateError(
     const translation = ERROR_TRANSLATIONS[errorCode];
     return {
       message: translation.message,
-      suggestion: translation.suggestion,
+      // Priorizar sugerencia del backend sobre la local
+      suggestion: backendSuggestion || translation.suggestion,
     };
   }
   
@@ -204,7 +376,8 @@ export function translateError(
     if (errorMessage.includes(pattern) || errorMessage === pattern) {
       return {
         message: translation.message,
-        suggestion: translation.suggestion,
+        // Priorizar sugerencia del backend sobre la local
+        suggestion: backendSuggestion || translation.suggestion,
       };
     }
   }
@@ -223,7 +396,8 @@ export function translateError(
     if (isSpanishMessage && !isTechnicalMessage) {
       return {
         message: errorMessage,
-        suggestion: 'Si el problema persiste, contacta al administrador',
+        // Priorizar sugerencia del backend
+        suggestion: backendSuggestion || 'Si el problema persiste, contacta al administrador',
       };
     }
     
@@ -241,14 +415,16 @@ export function translateError(
     
     return {
       message: friendlyMessage,
-      suggestion: 'Si el problema persiste, contacta al administrador',
+      // Priorizar sugerencia del backend
+      suggestion: backendSuggestion || 'Si el problema persiste, contacta al administrador',
     };
   }
   
   // Ultimate fallback
   return {
     message: 'Ocurrió un error inesperado',
-    suggestion: 'Por favor intenta nuevamente o contacta al administrador si el problema persiste',
+    // Priorizar sugerencia del backend
+    suggestion: backendSuggestion || 'Por favor intenta nuevamente o contacta al administrador si el problema persiste',
   };
 }
 

--- a/src/views/Configuracion.tsx
+++ b/src/views/Configuracion.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTheme } from '../context/ThemeContext';
+import { Button } from '../components/ui';
 import './Configuracion.css';
 
 const Configuracion: React.FC = () => {
@@ -36,13 +37,13 @@ const Configuracion: React.FC = () => {
             <label className="config-label">Tema:</label>
             <div className="theme-toggle-container">
               <span className="theme-label">Modo claro</span>
-              <button 
+              <Button
                 className={`theme-toggle ${isDarkMode ? 'active' : ''}`}
                 onClick={toggleTheme}
                 aria-label={`Cambiar a modo ${isDarkMode ? 'claro' : 'oscuro'}`}
               >
                 <div className="theme-toggle-thumb"></div>
-              </button>
+              </Button>
               <span className="theme-label">Modo oscuro</span>
             </div>
           </div>
@@ -69,12 +70,12 @@ const Configuracion: React.FC = () => {
         </div>
 
         <div className="config-actions">
-          <button className="config-btn primary">
+          <Button className="config-btn primary">
             Guardar Configuración
-          </button>
-          <button className="config-btn secondary">
+          </Button>
+          <Button className="config-btn secondary">
             Restaurar Defaults
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -4,6 +4,7 @@ import { useScannedCodeContext } from '../context/ScannedCodeContext';
 import { useScanContext } from '../context/ScanContext';
 import { formatCodeForDisplay } from '../api';
 import ReportIssueModal from '../components/ReportIssueModal/ReportIssueModal';
+import { Button } from '../components/ui';
 import './Dashboard.css';
 
 const Dashboard: React.FC = () => {
@@ -114,32 +115,31 @@ const Dashboard: React.FC = () => {
     <div className="dashboard-content">
       {/* Sección de Acciones */}
       <div className="actions-section">
-        <button 
+        <Button
           className="action-btn primary"
           onClick={handleRegistrarCaja}
         >
           <span className="btn-text">Recibir Pallets o Cajas</span>
-        </button>
+        </Button>
 
-        <button 
+        <Button
           className="action-btn"
           onClick={() => navigate('/consultar-codigo')}
         >
           <span className="btn-text">Consultar Código</span>
-        </button>
+        </Button>
 
-        <button 
+        <Button
           className="action-btn"
           onClick={() => navigate('/crear-pallet')}
         >
           <span className="btn-text">Crear Pallet</span>
-        </button>
-        
-        
-        <button className="action-btn"
-        onClick={handleReportClick}>
+        </Button>
+
+
+        <Button className="action-btn" onClick={handleReportClick}>
           <span className="btn-text">Registrar Problema</span>
-        </button>
+        </Button>
       </div>
 
       {/* Último Código Procesado */}

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -136,6 +136,12 @@ const Dashboard: React.FC = () => {
           <span className="btn-text">Crear Pallet</span>
         </Button>
 
+        <Button
+          className="action-btn"
+          onClick={() => navigate('/despachar-venta')}
+        >
+          <span className="btn-text">Despachar Ventas</span>
+        </Button>
 
         <Button className="action-btn" onClick={handleReportClick}>
           <span className="btn-text">Registrar Problema</span>

--- a/src/views/DespacharVenta/DespacharVenta.css
+++ b/src/views/DespacharVenta/DespacharVenta.css
@@ -1,0 +1,452 @@
+.despachar-venta-container {
+  padding: var(--spacing-md);
+  max-width: 100%;
+  min-height: 100%;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-lg);
+  gap: var(--spacing-md);
+}
+
+.header h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+  color: var(--text-primary);
+  flex: 1;
+}
+
+.refresh-button,
+.retry-button {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--btn-primary-bg);
+  color: var(--text-white, white);
+  border: none;
+  border-radius: var(--corner-radius);
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 500;
+  min-height: var(--touch-size);
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.refresh-button:hover:not(:disabled),
+.retry-button:hover:not(:disabled) {
+  background-color: var(--industrial-primary-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px var(--shadow-medium);
+}
+
+.refresh-button:active:not(:disabled),
+.retry-button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.refresh-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.loading-message,
+.error-message,
+.no-sales-message {
+  text-align: center;
+  padding: var(--spacing-lg);
+  color: var(--text-secondary);
+  font-size: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+}
+
+.loading-message {
+  gap: var(--spacing-md);
+}
+
+.loading-spinner {
+  width: 48px;
+  height: 48px;
+  border: 4px solid var(--color-surface);
+  border-top-color: var(--btn-primary-bg);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.no-sales-message {
+  gap: var(--spacing-sm);
+}
+
+.empty-icon {
+  font-size: 4rem;
+  margin-bottom: var(--spacing-md);
+  animation: float 3s ease-in-out infinite;
+  filter: grayscale(0.3);
+}
+
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
+}
+
+.empty-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.empty-subtitle {
+  font-size: 0.875rem;
+  margin-top: var(--spacing-sm);
+  opacity: 0.7;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.error-message {
+  color: #dc3545;
+  background-color: #fff5f5;
+  border: 1px solid #fed7d7;
+  border-radius: var(--corner-radius);
+  padding: var(--spacing-md);
+  min-height: auto;
+}
+
+.sales-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  animation: fadeInUp 0.3s ease-out;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.sale-card {
+  background: var(--background-white);
+  border: 1px solid var(--color-border);
+  border-radius: var(--corner-radius);
+  padding: var(--spacing-md);
+  box-shadow: 0 2px 8px var(--shadow-light);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+}
+
+.sale-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 100%;
+  background-color: var(--btn-primary-bg);
+  transform: scaleY(0);
+  transition: transform 0.3s ease;
+}
+
+.sale-card:hover::before {
+  transform: scaleY(1);
+}
+
+.sale-card:active {
+  transform: scale(0.98);
+  box-shadow: 0 1px 4px var(--shadow-light);
+}
+
+.sale-card.complete {
+  border-color: var(--industrial-success);
+  background: linear-gradient(135deg, #f0f9f0 0%, #ffffff 100%);
+  border-width: 2px;
+  box-shadow: 0 4px 12px rgba(52, 199, 89, 0.15);
+}
+
+.sale-card.complete::before {
+  background-color: var(--industrial-success);
+  transform: scaleY(1);
+}
+
+.sale-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: var(--spacing-md);
+  gap: var(--spacing-md);
+}
+
+.sale-header-left {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  flex: 1;
+}
+
+.sale-number {
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: var(--btn-primary-bg);
+  letter-spacing: 0.02em;
+  line-height: 1.2;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.625rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.complete-badge {
+  background-color: var(--industrial-success);
+  color: white;
+  width: fit-content;
+}
+
+.sale-customer {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  text-align: right;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.sale-progress {
+  margin-bottom: var(--spacing-md);
+}
+
+.progress-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-sm);
+  font-size: 0.875rem;
+}
+
+.progress-label {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.progress-percentage {
+  font-weight: 700;
+  color: var(--btn-primary-bg);
+  font-size: 1rem;
+  background-color: var(--color-surface);
+  padding: 0.25rem 0.625rem;
+  border-radius: 12px;
+  min-width: 3rem;
+  text-align: center;
+}
+
+.progress-bar {
+  width: 100%;
+  height: 10px;
+  background-color: var(--color-surface);
+  border-radius: 5px;
+  overflow: hidden;
+  position: relative;
+}
+
+.progress-fill {
+  height: 100%;
+  background-color: var(--btn-primary-bg);
+  transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  border-radius: 5px;
+}
+
+.sale-card.complete .progress-fill {
+  background-color: var(--industrial-success);
+}
+
+.calibre-breakdown {
+  margin-top: var(--spacing-md);
+  padding-top: var(--spacing-md);
+  border-top: 1px solid var(--color-border);
+}
+
+.calibre-breakdown-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--spacing-sm);
+}
+
+.calibre-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--spacing-sm);
+}
+
+.calibre-chip {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--corner-radius);
+  font-size: 0.8125rem;
+  transition: all 0.2s ease;
+}
+
+.calibre-chip.complete {
+  background-color: #e8f5e9;
+  border-color: var(--industrial-success);
+}
+
+.calibre-chip .calibre-label {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 0.75rem;
+}
+
+.calibre-chip .calibre-count {
+  font-weight: 500;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
+.calibre-chip.complete .calibre-count {
+  color: var(--industrial-success);
+  font-weight: 600;
+}
+
+.sale-eggs {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-surface);
+  border-radius: var(--corner-radius);
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.eggs-icon {
+  font-size: 1.125rem;
+}
+
+.eggs-text {
+  flex: 1;
+}
+
+.dispatch-button {
+  width: 100%;
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-md);
+  background-color: var(--btn-primary-bg);
+  color: var(--text-white, white);
+  border: none;
+  border-radius: var(--corner-radius);
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: var(--touch-size);
+  transition: all 0.2s ease;
+  box-shadow: 0 2px 8px rgba(0, 122, 255, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  position: relative;
+  overflow: hidden;
+}
+
+.dispatch-button::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.3);
+  transform: translate(-50%, -50%);
+  transition: width 0.6s, height 0.6s;
+}
+
+.dispatch-button:active:not(:disabled)::before {
+  width: 300px;
+  height: 300px;
+}
+
+.dispatch-button:hover:not(:disabled) {
+  background-color: var(--industrial-primary-dark);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 122, 255, 0.3);
+}
+
+.dispatch-button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.dispatch-button:disabled {
+  background-color: var(--industrial-success);
+  cursor: not-allowed;
+  opacity: 0.9;
+  box-shadow: 0 2px 4px rgba(52, 199, 89, 0.2);
+}
+
+.button-icon {
+  font-size: 1.125rem;
+  line-height: 1;
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .header h1 {
+    font-size: 1.25rem;
+  }
+
+  .refresh-button {
+    width: 100%;
+  }
+
+  .sale-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .sale-customer {
+    text-align: left;
+  }
+}
+

--- a/src/views/DespacharVenta/DespacharVenta.tsx
+++ b/src/views/DespacharVenta/DespacharVenta.tsx
@@ -1,0 +1,210 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getConfirmedSales } from '@/api/endpoints';
+import './DespacharVenta.css';
+
+interface Sale {
+  saleId: string;
+  saleNumber?: string;
+  customerName?: string;
+  type?: string;
+  totalBoxes?: number;
+  totalEggs?: number;
+  metadata?: {
+    requestedBoxesByCalibre?: Array<{ calibre: string; boxCount: number }>;
+    totalRequestedBoxes?: number;
+    boxesByCalibre?: Record<string, number>;
+  };
+  createdAt: string;
+}
+
+const DespacharVenta: React.FC = () => {
+  const navigate = useNavigate();
+  const [sales, setSales] = useState<Sale[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadSales();
+  }, []);
+
+  const loadSales = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await getConfirmedSales({
+        pagination: { limit: 50 },
+      });
+      
+      // Handle different response formats
+      const salesList = response?.items || response?.sales || response || [];
+      setSales(Array.isArray(salesList) ? salesList : []);
+    } catch (err) {
+      console.error('Error loading sales:', err);
+      setError(err instanceof Error ? err.message : 'Error al cargar ventas');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDispatch = (sale: Sale) => {
+    navigate(`/escanear-venta/${sale.saleId}`);
+  };
+
+  const getProgressPercentage = (sale: Sale): number => {
+    const requested = sale.metadata?.totalRequestedBoxes || 0;
+    const current = sale.totalBoxes || 0;
+    if (requested === 0) return 0;
+    return Math.round((current / requested) * 100);
+  };
+
+  const isComplete = (sale: Sale): boolean => {
+    const requested = sale.metadata?.totalRequestedBoxes || 0;
+    const current = sale.totalBoxes || 0;
+    return requested > 0 && current >= requested;
+  };
+
+  if (loading) {
+    return (
+      <div className="despachar-venta-container">
+        <div className="header">
+          <h1>Despachar Ventas</h1>
+        </div>
+        <div className="loading-message">
+          <div className="loading-spinner"></div>
+          <div>Cargando ventas...</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="despachar-venta-container">
+        <div className="error-message">{error}</div>
+        <button onClick={loadSales} className="retry-button">
+          Reintentar
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="despachar-venta-container">
+      <div className="header">
+        <h1>Despachar Ventas</h1>
+        <button onClick={loadSales} className="refresh-button">
+          Actualizar
+        </button>
+      </div>
+
+      {sales.length === 0 ? (
+        <div className="no-sales-message">
+          <div className="empty-icon">📦</div>
+          <p className="empty-title">No hay ventas confirmadas para despachar</p>
+          <p className="empty-subtitle">
+            Las ventas aparecerán aquí una vez que sean confirmadas
+          </p>
+        </div>
+      ) : (
+        <div className="sales-list">
+          {sales.map((sale) => {
+            const progress = getProgressPercentage(sale);
+            const complete = isComplete(sale);
+
+            return (
+              <div key={sale.saleId} className={`sale-card ${complete ? 'complete' : ''}`}>
+                <div className="sale-header">
+                  <div className="sale-header-left">
+                    <div className="sale-number">
+                      {sale.saleNumber || sale.saleId.substring(0, 8)}
+                    </div>
+                    {complete && (
+                      <span className="status-badge complete-badge">
+                        ✓ Completa
+                      </span>
+                    )}
+                  </div>
+                  <div className="sale-customer">
+                    {sale.customerName || 'Cliente sin nombre'}
+                  </div>
+                </div>
+
+                <div className="sale-progress">
+                  <div className="progress-info">
+                    <span className="progress-label">
+                      {sale.totalBoxes || 0} / {sale.metadata?.totalRequestedBoxes || 0} cajas
+                    </span>
+                    <span className="progress-percentage">{progress}%</span>
+                  </div>
+                  <div className="progress-bar">
+                    <div
+                      className="progress-fill"
+                      style={{ width: `${progress}%` }}
+                      role="progressbar"
+                      aria-valuenow={progress}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                    />
+                  </div>
+                </div>
+
+                {sale.metadata?.requestedBoxesByCalibre && (
+                  <div className="calibre-breakdown">
+                    <div className="calibre-breakdown-title">Por Calibre:</div>
+                    <div className="calibre-grid">
+                      {sale.metadata.requestedBoxesByCalibre.map((req) => {
+                        const current =
+                          sale.metadata?.boxesByCalibre?.[req.calibre] || 0;
+                        const calibreComplete = current >= req.boxCount;
+                        return (
+                          <div key={req.calibre} className={`calibre-chip ${calibreComplete ? 'complete' : ''}`}>
+                            <span className="calibre-label">Calibre {req.calibre}</span>
+                            <span className="calibre-count">
+                              {current} / {req.boxCount}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                {sale.totalEggs !== undefined && sale.totalEggs > 0 && (
+                  <div className="sale-eggs">
+                    <span className="eggs-icon">🥚</span>
+                    <span className="eggs-text">
+                      {sale.totalEggs.toLocaleString()} huevos
+                    </span>
+                  </div>
+                )}
+
+                <button
+                  onClick={() => handleDispatch(sale)}
+                  className="dispatch-button"
+                  disabled={complete}
+                  aria-label={complete ? 'Venta completa' : `Despachar venta ${sale.saleNumber || sale.saleId}`}
+                >
+                  {complete ? (
+                    <>
+                      <span className="button-icon">✓</span>
+                      <span>Completa</span>
+                    </>
+                  ) : (
+                    <>
+                      <span className="button-icon">📦</span>
+                      <span>Despachar</span>
+                    </>
+                  )}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DespacharVenta;
+

--- a/src/views/EscanearVenta/EscanearVenta.css
+++ b/src/views/EscanearVenta/EscanearVenta.css
@@ -1,0 +1,826 @@
+.escanear-venta-container {
+  padding: var(--spacing-md);
+  max-width: 100%;
+  padding-bottom: calc(var(--spacing-lg) * 2);
+  min-height: 100%;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+}
+
+.header h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+  color: var(--text-primary);
+  flex: 1;
+}
+
+.back-button {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--btn-secondary-bg);
+  color: var(--text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--corner-radius);
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 500;
+  min-height: var(--touch-size);
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.back-button:hover:not(:disabled) {
+  background-color: var(--color-surface);
+  transform: translateY(-1px);
+}
+
+.back-button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.sale-info-card {
+  background: var(--background-white);
+  border: 1px solid var(--color-border);
+  border-radius: var(--corner-radius);
+  padding: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+  box-shadow: 0 2px 8px var(--shadow-light);
+  position: relative;
+  overflow: hidden;
+}
+
+.sale-info-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 100%;
+  background-color: var(--btn-primary-bg);
+}
+
+.sale-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-sm);
+  gap: var(--spacing-sm);
+}
+
+.sale-number {
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: var(--btn-primary-bg);
+  letter-spacing: 0.02em;
+  line-height: 1.2;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.625rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.complete-badge {
+  background-color: var(--industrial-success);
+  color: white;
+  white-space: nowrap;
+}
+
+.sale-customer {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-md);
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.progress-section {
+  margin-bottom: 1rem;
+}
+
+.progress-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-sm);
+  font-size: 0.875rem;
+}
+
+.progress-label {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.progress-percentage {
+  font-weight: 700;
+  color: var(--btn-primary-bg);
+  font-size: 1rem;
+  background-color: var(--color-surface);
+  padding: 0.25rem 0.625rem;
+  border-radius: 12px;
+  min-width: 3rem;
+  text-align: center;
+}
+
+.progress-bar {
+  width: 100%;
+  height: 10px;
+  background-color: var(--color-surface);
+  border-radius: 5px;
+  overflow: hidden;
+  position: relative;
+}
+
+.progress-fill {
+  height: 100%;
+  background-color: var(--btn-primary-bg);
+  transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  border-radius: 5px;
+}
+
+.total-eggs {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-surface);
+  border-radius: var(--corner-radius);
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.eggs-icon {
+  font-size: 1.125rem;
+}
+
+.eggs-text {
+  flex: 1;
+}
+
+.calibre-breakdown {
+  margin-top: var(--spacing-md);
+  padding-top: var(--spacing-md);
+  border-top: 1px solid var(--color-border);
+}
+
+.calibre-breakdown-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--spacing-sm);
+}
+
+.calibre-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: var(--spacing-sm);
+}
+
+.calibre-chip {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--corner-radius);
+  font-size: 0.8125rem;
+  transition: all 0.2s ease;
+}
+
+.calibre-chip.complete {
+  background-color: #e8f5e9;
+  border-color: var(--industrial-success);
+}
+
+.calibre-chip .calibre-label {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 0.75rem;
+}
+
+.calibre-chip .calibre-count {
+  font-weight: 500;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
+.calibre-chip.complete .calibre-count {
+  color: var(--industrial-success);
+  font-weight: 600;
+}
+
+.scan-section {
+  margin-bottom: 1.5rem;
+}
+
+.scan-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-md);
+}
+
+.scan-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.scanning-indicator {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: 0.875rem;
+  color: var(--btn-primary-bg);
+  font-weight: 500;
+}
+
+.scanning-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--btn-primary-bg);
+  animation: pulse-dot 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse-dot {
+  0%, 100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.5;
+    transform: scale(1.2);
+  }
+}
+
+.scan-input-container {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-md);
+}
+
+.input-wrapper {
+  flex: 1;
+  position: relative;
+}
+
+.input-length-indicator {
+  position: absolute;
+  top: -1.5rem;
+  right: 0;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.scan-input {
+  width: 100%;
+  padding: var(--spacing-md);
+  border: 2px solid var(--color-border);
+  border-radius: var(--corner-radius);
+  font-size: 1rem;
+  font-family: 'Courier New', monospace;
+  letter-spacing: 0.05em;
+  background-color: var(--background-white);
+  color: var(--text-primary);
+  transition: all 0.2s ease;
+  min-height: var(--touch-size);
+  box-sizing: border-box;
+}
+
+.scan-input:focus {
+  outline: none;
+  border-color: var(--btn-primary-bg);
+  box-shadow: 0 0 0 3px var(--shadow-focus);
+  background-color: #fafafa;
+}
+
+.scan-input.scanning {
+  border-color: var(--btn-primary-bg);
+  background: linear-gradient(90deg, 
+    var(--background-white) 0%, 
+    rgba(0, 122, 255, 0.05) 50%, 
+    var(--background-white) 100%);
+  background-size: 200% 100%;
+  animation: scanning-shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes scanning-shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.scan-input.complete {
+  border-color: var(--industrial-success);
+  background-color: #f0f9f0;
+}
+
+.scan-input:disabled {
+  background-color: var(--color-surface);
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.scan-button {
+  padding: var(--spacing-md) var(--spacing-lg);
+  background-color: var(--btn-primary-bg);
+  color: var(--text-white, white);
+  border: none;
+  border-radius: var(--corner-radius);
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: var(--touch-size);
+  min-width: 120px;
+  transition: all 0.2s ease;
+  box-shadow: 0 2px 8px rgba(0, 122, 255, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  position: relative;
+  overflow: hidden;
+}
+
+.scan-button::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.3);
+  transform: translate(-50%, -50%);
+  transition: width 0.6s, height 0.6s;
+}
+
+.scan-button:active:not(:disabled)::before {
+  width: 300px;
+  height: 300px;
+}
+
+.scan-button:hover:not(:disabled) {
+  background-color: var(--industrial-primary-dark);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 122, 255, 0.3);
+}
+
+.scan-button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.scan-button:disabled {
+  background-color: var(--color-surface);
+  color: var(--text-secondary);
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.scan-button .button-icon {
+  font-size: 1.125rem;
+  line-height: 1;
+  display: inline-block;
+}
+
+.scan-button .button-icon.spinning {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.error-message {
+  padding: var(--spacing-md);
+  background-color: #fff5f5;
+  color: #dc3545;
+  border: 1px solid #fed7d7;
+  border-radius: var(--corner-radius);
+  margin-bottom: var(--spacing-sm);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  animation: shake 0.4s ease-out;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+}
+
+.error-message::before {
+  content: '⚠️';
+  font-size: 1.125rem;
+  flex-shrink: 0;
+}
+
+@keyframes shake {
+  0%, 100% {
+    transform: translateX(0);
+  }
+  10%, 30%, 50%, 70%, 90% {
+    transform: translateX(-5px);
+  }
+  20%, 40%, 60%, 80% {
+    transform: translateX(5px);
+  }
+}
+
+.success-message {
+  padding: var(--spacing-md);
+  background-color: #f0f9f0;
+  color: var(--industrial-success);
+  border: 1px solid #c6f6d5;
+  border-radius: var(--corner-radius);
+  margin-bottom: var(--spacing-sm);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  animation: slideDown 0.3s ease-out;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+}
+
+.success-message::before {
+  content: '✓';
+  font-size: 1.125rem;
+  flex-shrink: 0;
+  color: var(--industrial-success);
+  font-weight: 700;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.complete-message {
+  padding: var(--spacing-md);
+  background: linear-gradient(135deg, #e8f5e9 0%, #f0f9f0 100%);
+  color: var(--industrial-success);
+  border: 2px solid var(--industrial-success);
+  border-radius: var(--corner-radius);
+  font-weight: 600;
+  text-align: center;
+  font-size: 0.9375rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-sm);
+  animation: pulse 2s ease-in-out infinite;
+  box-shadow: 0 4px 12px rgba(52, 199, 89, 0.2);
+}
+
+@keyframes pulse {
+  0%, 100% {
+    box-shadow: 0 4px 12px rgba(52, 199, 89, 0.2);
+  }
+  50% {
+    box-shadow: 0 4px 20px rgba(52, 199, 89, 0.4);
+  }
+}
+
+.scanned-items-section {
+  margin-top: 1.5rem;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-md);
+}
+
+.scanned-items-section h2 {
+  font-size: 1.2rem;
+  margin: 0;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.items-counter {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.125rem;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--btn-primary-bg);
+  color: white;
+  border-radius: var(--corner-radius);
+  min-width: 60px;
+}
+
+.counter-number {
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.counter-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.9;
+}
+
+.no-items {
+  text-align: center;
+  padding: 2rem;
+  color: var(--color-text-secondary, #666);
+}
+
+.items-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  animation: fadeIn 0.3s ease-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.scanned-item {
+  animation: slideIn 0.3s ease-out;
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.scanned-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--background-white);
+  border: 1px solid var(--color-border);
+  border-radius: var(--corner-radius);
+  padding: var(--spacing-md);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  gap: var(--spacing-md);
+  position: relative;
+  overflow: hidden;
+}
+
+.scanned-item::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 3px;
+  height: 100%;
+  background-color: var(--btn-primary-bg);
+  transform: scaleY(0);
+  transition: transform 0.3s ease;
+}
+
+.scanned-item:hover::before {
+  transform: scaleY(1);
+}
+
+.scanned-item:active {
+  transform: scale(0.98);
+  background-color: var(--color-surface);
+}
+
+.item-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.item-header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-sm);
+}
+
+.item-code {
+  font-weight: 700;
+  font-size: 0.9375rem;
+  font-family: 'Courier New', monospace;
+  letter-spacing: 0.05em;
+  color: var(--text-primary);
+  word-break: break-all;
+  line-height: 1.3;
+  flex: 1;
+  min-width: 0;
+}
+
+.item-type-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.25rem 0.625rem;
+  border-radius: 12px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.item-type-badge.box {
+  background-color: #dbeafe;
+  color: #1e40af;
+}
+
+.item-type-badge.pallet {
+  background-color: #d1fae5;
+  color: #065f46;
+}
+
+.item-details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-md);
+  margin-top: var(--spacing-sm);
+}
+
+.item-detail {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: 0.8125rem;
+}
+
+.detail-label {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.detail-value {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.remove-button {
+  padding: var(--spacing-sm);
+  background-color: #dc3545;
+  color: white;
+  border: none;
+  border-radius: var(--corner-radius);
+  cursor: pointer;
+  font-size: 1.125rem;
+  width: var(--touch-size);
+  height: var(--touch-size);
+  min-width: var(--touch-size);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+}
+
+.remove-button:hover:not(:disabled) {
+  background-color: #c82333;
+  transform: scale(1.05);
+}
+
+.remove-button:active:not(:disabled) {
+  transform: scale(0.95);
+}
+
+.remove-button:disabled {
+  background-color: var(--color-surface);
+  color: var(--text-secondary);
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.loading-message {
+  text-align: center;
+  padding: var(--spacing-lg);
+  color: var(--text-secondary);
+  font-size: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  gap: var(--spacing-md);
+}
+
+.loading-spinner {
+  width: 48px;
+  height: 48px;
+  border: 4px solid var(--color-surface);
+  border-top-color: var(--btn-primary-bg);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.no-items {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-lg);
+}
+
+.empty-icon {
+  font-size: 3rem;
+  margin-bottom: var(--spacing-sm);
+  animation: float 3s ease-in-out infinite;
+  filter: grayscale(0.3);
+}
+
+.empty-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.empty-subtitle {
+  font-size: 0.875rem;
+  margin-top: var(--spacing-sm);
+  opacity: 0.7;
+  color: var(--text-secondary);
+  text-align: center;
+  margin: 0;
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .header {
+    flex-wrap: wrap;
+  }
+
+  .header h1 {
+    font-size: 1.25rem;
+  }
+
+  .back-button {
+    width: 100%;
+  }
+
+  .scan-input-container {
+    flex-direction: column;
+  }
+
+  .scan-button {
+    width: 100%;
+  }
+
+  .scanned-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .remove-button {
+    align-self: flex-end;
+  }
+}
+

--- a/src/views/EscanearVenta/EscanearVenta.tsx
+++ b/src/views/EscanearVenta/EscanearVenta.tsx
@@ -1,0 +1,442 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  getSaleById,
+  addBoxToSale,
+  addPalletToSale,
+  removeBoxFromSale,
+  removePalletFromSale,
+  getInfoFromScannedCode,
+} from '@/api/endpoints';
+import { translateError } from '@/utils/errorMessages';
+import './EscanearVenta.css';
+
+interface ScannedItem {
+  code: string;
+  type: 'box' | 'pallet';
+  calibre?: string;
+  eggs?: number;
+  timestamp: string;
+}
+
+const EscanearVenta: React.FC = () => {
+  const { saleId } = useParams<{ saleId: string }>();
+  const navigate = useNavigate();
+  const [sale, setSale] = useState<any>(null);
+  const [scanInput, setScanInput] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [scanning, setScanning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [scannedItems, setScannedItems] = useState<ScannedItem[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (saleId) {
+      loadSale();
+    }
+  }, [saleId]);
+
+  useEffect(() => {
+    // Auto-focus input on mount
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  const loadSale = async () => {
+    if (!saleId) return;
+    try {
+      setLoading(true);
+      setError(null);
+      const saleData = await getSaleById(saleId);
+      setSale(saleData);
+      
+      // Load existing scanned items
+      if (saleData.boxes || saleData.pallets) {
+        const items: ScannedItem[] = [];
+        if (saleData.boxes) {
+          for (const boxCode of saleData.boxes) {
+            try {
+              const info = await getInfoFromScannedCode({ codigo: boxCode });
+              if (info.data) {
+                items.push({
+                  code: boxCode,
+                  type: 'box',
+                  calibre: info.data.calibre,
+                  eggs: info.data.eggs,
+                  timestamp: new Date().toISOString(),
+                });
+              }
+            } catch (err) {
+              // Skip if can't load
+            }
+          }
+        }
+        if (saleData.pallets) {
+          for (const palletCode of saleData.pallets) {
+            items.push({
+              code: palletCode,
+              type: 'pallet',
+              timestamp: new Date().toISOString(),
+            });
+          }
+        }
+        setScannedItems(items);
+      }
+    } catch (err) {
+      console.error('Error loading sale:', err);
+      setError(err instanceof Error ? err.message : 'Error al cargar la venta');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleScan = async (code: string) => {
+    if (!code || !saleId) return;
+
+    const trimmedCode = code.trim();
+    if (trimmedCode.length === 0) return;
+
+    try {
+      setScanning(true);
+      setError(null);
+      setSuccess(null);
+
+      // Determine if it's a box (16 digits) or pallet (13-14 digits)
+      const isBox = trimmedCode.length === 16;
+      const isPallet = trimmedCode.length === 13 || trimmedCode.length === 14;
+
+      if (!isBox && !isPallet) {
+        throw new Error('Código inválido. Debe ser una caja (16 dígitos) o pallet (13-14 dígitos)');
+      }
+
+      // Get info from scanned code
+      const info = await getInfoFromScannedCode({ codigo: trimmedCode });
+      
+      if (!info.success || !info.data) {
+        throw new Error('No se pudo obtener información del código escaneado');
+      }
+
+      // Add to sale
+      if (isBox) {
+        await addBoxToSale({ saleId, boxCode: trimmedCode });
+        setScannedItems((prev) => [
+          ...prev,
+          {
+            code: trimmedCode,
+            type: 'box',
+            calibre: info.data.calibre,
+            eggs: info.data.eggs,
+            timestamp: new Date().toISOString(),
+          },
+        ]);
+        setSuccess(`Caja ${trimmedCode} agregada exitosamente`);
+      } else if (isPallet) {
+        await addPalletToSale({ saleId, palletCode: trimmedCode });
+        setScannedItems((prev) => [
+          ...prev,
+          {
+            code: trimmedCode,
+            type: 'pallet',
+            timestamp: new Date().toISOString(),
+          },
+        ]);
+        setSuccess(`Pallet ${trimmedCode} agregado exitosamente`);
+      }
+
+      // Reload sale to get updated data
+      await loadSale();
+      
+      // Clear input
+      setScanInput('');
+      if (inputRef.current) {
+        inputRef.current.focus();
+      }
+    } catch (err) {
+      console.error('Error scanning:', err);
+      const { message, suggestion } = translateError(err, 'dispatch');
+      setError(suggestion ? `${message}. ${suggestion}` : message);
+    } finally {
+      setScanning(false);
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setScanInput(e.target.value);
+  };
+
+  const handleInputKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && scanInput.trim()) {
+      handleScan(scanInput);
+    }
+  };
+
+  const handleRemoveItem = async (item: ScannedItem) => {
+    if (!saleId) return;
+    try {
+      setError(null);
+      if (item.type === 'box') {
+        await removeBoxFromSale({ saleId, boxCode: item.code });
+      } else {
+        await removePalletFromSale({ saleId, palletCode: item.code });
+      }
+      setScannedItems((prev) => prev.filter((i) => i.code !== item.code));
+      await loadSale();
+      setSuccess('Item removido exitosamente');
+    } catch (err) {
+      const { message, suggestion } = translateError(err, 'dispatch');
+      setError(suggestion ? `${message}. ${suggestion}` : message);
+    }
+  };
+
+  const getProgressPercentage = (): number => {
+    const requested = sale?.metadata?.totalRequestedBoxes || 0;
+    const current = sale?.totalBoxes || 0;
+    if (requested === 0) return 0;
+    return Math.round((current / requested) * 100);
+  };
+
+  const isComplete = (): boolean => {
+    const requested = sale?.metadata?.totalRequestedBoxes || 0;
+    const current = sale?.totalBoxes || 0;
+    return requested > 0 && current >= requested;
+  };
+
+  if (loading) {
+    return (
+      <div className="escanear-venta-container">
+        <div className="header">
+          <button onClick={() => navigate('/despachar-venta')} className="back-button">
+            ← Volver
+          </button>
+          <h1>Escanear Venta</h1>
+        </div>
+        <div className="loading-message">
+          <div className="loading-spinner"></div>
+          <div>Cargando venta...</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!sale) {
+    return (
+      <div className="escanear-venta-container">
+        <div className="error-message">Venta no encontrada</div>
+        <button onClick={() => navigate('/despachar-venta')} className="back-button">
+          Volver
+        </button>
+      </div>
+    );
+  }
+
+  const progress = getProgressPercentage();
+  const complete = isComplete();
+
+  return (
+    <div className="escanear-venta-container">
+      <div className="header">
+        <button onClick={() => navigate('/despachar-venta')} className="back-button">
+          ← Volver
+        </button>
+        <h1>Escanear Venta</h1>
+      </div>
+
+      <div className="sale-info-card">
+        <div className="sale-card-header">
+          <div className="sale-number">{sale.saleNumber || sale.saleId.substring(0, 8)}</div>
+          {complete && (
+            <span className="status-badge complete-badge">
+              ✓ Completa
+            </span>
+          )}
+        </div>
+        <div className="sale-customer">{sale.customerName || 'Cliente sin nombre'}</div>
+        
+        <div className="progress-section">
+          <div className="progress-info">
+            <span className="progress-label">
+              {sale.totalBoxes || 0} / {sale.metadata?.totalRequestedBoxes || 0} cajas
+            </span>
+            <span className="progress-percentage">{progress}%</span>
+          </div>
+          <div className="progress-bar">
+            <div 
+              className="progress-fill" 
+              style={{ width: `${progress}%` }}
+              role="progressbar"
+              aria-valuenow={progress}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            />
+          </div>
+        </div>
+
+        {sale.totalEggs !== undefined && sale.totalEggs > 0 && (
+          <div className="total-eggs">
+            <span className="eggs-icon">🥚</span>
+            <span className="eggs-text">
+              {sale.totalEggs.toLocaleString()} huevos
+            </span>
+          </div>
+        )}
+
+        {sale.metadata?.requestedBoxesByCalibre && (
+          <div className="calibre-breakdown">
+            <div className="calibre-breakdown-title">Por Calibre:</div>
+            <div className="calibre-grid">
+              {sale.metadata.requestedBoxesByCalibre.map((req: any) => {
+                const current = sale.metadata?.boxesByCalibre?.[req.calibre] || 0;
+                const calibreComplete = current >= req.boxCount;
+                return (
+                  <div key={req.calibre} className={`calibre-chip ${calibreComplete ? 'complete' : ''}`}>
+                    <span className="calibre-label">Calibre {req.calibre}</span>
+                    <span className="calibre-count">
+                      {current} / {req.boxCount}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="scan-section">
+        <div className="scan-section-header">
+          <h3 className="scan-title">Escanear Código</h3>
+          {scanning && (
+            <div className="scanning-indicator">
+              <span className="scanning-dot"></span>
+              <span className="scanning-text">Procesando...</span>
+            </div>
+          )}
+        </div>
+        <div className="scan-input-container">
+          <div className="input-wrapper">
+            <input
+              ref={inputRef}
+              type="text"
+              value={scanInput}
+              onChange={handleInputChange}
+              onKeyPress={handleInputKeyPress}
+              placeholder="Escanear código de caja o pallet..."
+              className={`scan-input ${scanning ? 'scanning' : ''} ${complete ? 'complete' : ''}`}
+              disabled={scanning || complete}
+              autoFocus
+              autoComplete="off"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              aria-label="Campo de escaneo de código"
+            />
+            {scanInput.length > 0 && !scanning && (
+              <div className="input-length-indicator">
+                {scanInput.length} dígitos
+              </div>
+            )}
+          </div>
+          <button
+            onClick={() => handleScan(scanInput)}
+            disabled={!scanInput.trim() || scanning || complete}
+            className="scan-button"
+            aria-label={scanning ? 'Escaneando código' : 'Agregar código escaneado'}
+          >
+            {scanning ? (
+              <>
+                <span className="button-icon spinning">⏳</span>
+                <span>Escaneando...</span>
+              </>
+            ) : (
+              <>
+                <span className="button-icon">✓</span>
+                <span>Agregar</span>
+              </>
+            )}
+          </button>
+        </div>
+
+        {error && (
+          <div className="error-message">{error}</div>
+        )}
+
+        {success && (
+          <div className="success-message">{success}</div>
+        )}
+
+        {complete && (
+          <div className="complete-message">
+            <div style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>✓</div>
+            <div>Venta completa. Todas las cajas han sido escaneadas.</div>
+            <div style={{ fontSize: '0.875rem', marginTop: '0.5rem', opacity: 0.9 }}>
+              Puedes confirmar la venta desde el sistema administrativo
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="scanned-items-section">
+        <div className="section-header">
+          <h2>Items Escaneados</h2>
+          <div className="items-counter">
+            <span className="counter-number">{scannedItems.length}</span>
+            <span className="counter-label">items</span>
+          </div>
+        </div>
+        {scannedItems.length === 0 ? (
+          <div className="no-items">
+            <div className="empty-icon">📋</div>
+            <div className="empty-title">No hay items escaneados aún</div>
+            <div className="empty-subtitle">
+              Escanea cajas o pallets para agregarlos a la venta
+            </div>
+          </div>
+        ) : (
+          <div className="items-list">
+            {scannedItems.map((item, index) => (
+              <div 
+                key={item.code} 
+                className="scanned-item"
+                style={{ animationDelay: `${index * 0.05}s` }}
+              >
+                <div className="item-info">
+                  <div className="item-header-row">
+                    <div className="item-code">{item.code}</div>
+                    <span className={`item-type-badge ${item.type}`}>
+                      {item.type === 'box' ? 'Caja' : 'Pallet'}
+                    </span>
+                  </div>
+                  <div className="item-details">
+                    {item.calibre && (
+                      <div className="item-detail">
+                        <span className="detail-label">Calibre:</span>
+                        <span className="detail-value">{item.calibre}</span>
+                      </div>
+                    )}
+                    {item.eggs && (
+                      <div className="item-detail">
+                        <span className="detail-label">Huevos:</span>
+                        <span className="detail-value">{item.eggs.toLocaleString()}</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <button
+                  onClick={() => handleRemoveItem(item)}
+                  className="remove-button"
+                  disabled={complete}
+                  aria-label={`Remover ${item.type} ${item.code}`}
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default EscanearVenta;
+

--- a/src/views/Historial.tsx
+++ b/src/views/Historial.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useScannedCodeContext } from '../context/ScannedCodeContext';
 import { formatCodeForDisplay } from '../api';
+import { Button } from '../components/ui';
 import './Historial.css';
 
 const Historial: React.FC = () => {
@@ -97,12 +98,12 @@ const Historial: React.FC = () => {
         </div>
 
         {history.length > 0 && (
-          <button 
+          <Button
             onClick={clearHistory}
             className="clear-history-btn"
           >
             Limpiar Historial
-          </button>
+          </Button>
         )}
       </div>
 
@@ -111,7 +112,7 @@ const Historial: React.FC = () => {
         <div className="results-info">
           {filteredHistory.length} de {history.length} resultados
           {filteredHistory.length !== history.length && (
-            <button 
+            <Button
               onClick={() => {
                 setSearchTerm('');
                 setFilterType('all');
@@ -120,7 +121,7 @@ const Historial: React.FC = () => {
               className="clear-filters-btn"
             >
               Limpiar filtros
-            </button>
+            </Button>
           )}
         </div>
       ) : null}
@@ -185,13 +186,13 @@ const Historial: React.FC = () => {
               </div>
 
               <div className="card-footer">
-                <button
+                <Button
                   onClick={() => handleRescan(item.codigo)}
                   disabled={loading}
                   className="rescan-btn"
                 >
                   {loading ? '⏳' : '🔄'} Re-escanear
-                </button>
+                </Button>
                 
                 <span className="scan-date">
                   {new Date(item.fechaCreacion).toLocaleDateString('es-ES', {

--- a/src/views/Scanning/ConsultarCodigo/ConsultarCodigo.tsx
+++ b/src/views/Scanning/ConsultarCodigo/ConsultarCodigo.tsx
@@ -4,6 +4,7 @@ import { validateScannedCode } from '../../../utils/validators';
 import './ConsultarCodigo.css';
 import { useNavigate } from 'react-router-dom';
 import { useScannedCodeContext } from '../../../context/ScannedCodeContext';
+import { Button } from '../../../components/ui';
 
 interface ConsultaResult extends ScannedCodeInfo {
   timestamp: string;
@@ -139,26 +140,26 @@ const ConsultarCodigo: React.FC = () => {
     if (item.tipo === 'caja') {
       return (
         <div className="action-buttons">
-          <button className="btn-action btn-move">
+          <Button className="btn-action btn-move">
             📦 Mover Caja
-          </button>
-          <button className="btn-action btn-details">
+          </Button>
+          <Button className="btn-action btn-details">
             ℹ️ Ver Detalles
-          </button>
+          </Button>
         </div>
       );
     } else {
       return (
         <div className="action-buttons">
-          <button className="btn-action btn-move">
+          <Button className="btn-action btn-move">
             🚛 Mover Pallet
-          </button>
-          <button className="btn-action btn-contents">
+          </Button>
+          <Button className="btn-action btn-contents">
             📋 Ver Contenido
-          </button>
-          <button className="btn-action btn-details">
+          </Button>
+          <Button className="btn-action btn-details">
             ℹ️ Ver Detalles
-          </button>
+          </Button>
         </div>
       );
     }
@@ -167,9 +168,9 @@ const ConsultarCodigo: React.FC = () => {
   return (
     <div className="consultar-codigo">
       <div className="header">
-        <button onClick={handleBack} className="back-btn">
+        <Button onClick={handleBack} className="back-btn">
           ← Volver
-        </button>
+        </Button>
         <h2>🔍 Consultar Código</h2>
         <p>Ingresa un código para consultar su información</p>
       </div>
@@ -188,13 +189,13 @@ const ConsultarCodigo: React.FC = () => {
             disabled={loading}
             autoFocus
           />
-          <button 
-            type="submit" 
+          <Button
+            type="submit"
             className="search-button"
             disabled={loading || !codigo.trim()}
           >
             {loading ? '🔄' : '🔍'}
-          </button>
+          </Button>
         </div>
         
         {error && (

--- a/src/views/Scanning/ConsultarCodigo/ConsultarCodigo.tsx
+++ b/src/views/Scanning/ConsultarCodigo/ConsultarCodigo.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { ScannedCodeInfo } from '../../../api/types';
 import { validateScannedCode } from '../../../utils/validators';
+import { getUserFriendlyError } from '../../../utils/errorMessages';
 import './ConsultarCodigo.css';
 import { useNavigate } from 'react-router-dom';
 import { useScannedCodeContext } from '../../../context/ScannedCodeContext';
@@ -71,7 +72,8 @@ const ConsultarCodigo: React.FC = () => {
       setCodigo(''); // Clear input after successful search
     } catch (err: any) {
       console.error('Error consultando código:', err);
-      setError(err.message || 'Error al consultar el código');
+      // Use translation system for user-friendly error messages
+      setError(getUserFriendlyError(err, 'scan'));
       setResult(null);
     } finally {
       setLoading(false);

--- a/src/views/Scanning/CreatePalletForm/CreatePalletForm.tsx
+++ b/src/views/Scanning/CreatePalletForm/CreatePalletForm.tsx
@@ -6,6 +6,7 @@ import { CreatePalletFormProps } from './PalletForm.types';
 import { usePalletForm } from '../../../hooks/usePalletForm';
 import { PalletCodePreview } from './PalletCodePreview';
 import { TURNO_OPTIONS, CALIBRE_OPTIONS, FORMATO_OPTIONS } from './PalletFormConstants';
+import { Button } from '../../../components/ui';
 import './CreatePalletForm.css';
 
 /**
@@ -172,17 +173,17 @@ export const CreatePalletForm: React.FC<CreatePalletFormProps> = ({
       )}
         
         <div className="form-buttons">
-          <button 
-            type="button" 
-            className="btn btn-secondary" 
+          <Button
+            type="button"
+            className="btn btn-secondary"
             onClick={handleCancel}
             disabled={isSubmitting}
           >
             Cancelar
-          </button>
-          
-          <button 
-            type="submit" 
+          </Button>
+
+          <Button
+            type="submit"
             className={`btn btn-primary ${isSubmitting ? 'loading' : ''}`}
             disabled={isSubmitting || !generatedCode}
           >
@@ -194,7 +195,7 @@ export const CreatePalletForm: React.FC<CreatePalletFormProps> = ({
             ) : (
               'Crear Pallet'
             )}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/src/views/Scanning/RecibirCajaEnBodega/RecibirCaja.css
+++ b/src/views/Scanning/RecibirCajaEnBodega/RecibirCaja.css
@@ -135,20 +135,41 @@
 
 .error-message {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.75rem;
 }
 
 .error-icon {
   font-size: 1.25rem;
   flex-shrink: 0;
+  margin-top: 0.125rem;
+}
+
+.error-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .error-text {
-  flex: 1;
   color: #c53030;
   font-size: 0.875rem;
   font-weight: 500;
+  line-height: 1.4;
+}
+
+.error-suggestion {
+  color: #805ad5;
+  font-size: 0.8125rem;
+  font-weight: 400;
+  font-style: italic;
+  line-height: 1.4;
+  margin: 0;
+  padding: 0.5rem;
+  background-color: #faf5ff;
+  border-left: 3px solid #805ad5;
+  border-radius: 4px;
 }
 
 .error-close {

--- a/src/views/Scanning/RecibirCajaEnBodega/RecibirCaja.tsx
+++ b/src/views/Scanning/RecibirCajaEnBodega/RecibirCaja.tsx
@@ -16,7 +16,7 @@ const RegistrarCaja: React.FC = () => {
   const [pendingPalletCode, setPendingPalletCode] = useState('');
   const [reportReason, setReportReason] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
-  const { data, loading, error, processScan, reset } = useScanContext();
+  const { data, loading, error, errorInfo, processScan, reset } = useScanContext();
 
   const handleSubmit = async (e?: React.FormEvent) => {
     e?.preventDefault();
@@ -151,7 +151,12 @@ const RegistrarCaja: React.FC = () => {
         <div className="error-section">
           <div className="error-message">
             <span className="error-icon">⚠️</span>
-            <span className="error-text">{error}</span>
+            <div className="error-content">
+              <span className="error-text">{error}</span>
+              {errorInfo?.suggestion && (
+                <p className="error-suggestion">💡 {errorInfo.suggestion}</p>
+              )}
+            </div>
             <Button onClick={reset} className="error-close">✕</Button>
           </div>
         </div>

--- a/src/views/Scanning/RecibirCajaEnBodega/RecibirCaja.tsx
+++ b/src/views/Scanning/RecibirCajaEnBodega/RecibirCaja.tsx
@@ -4,6 +4,7 @@ import { useScanContext } from '../../../context/ScanContext';
 import { validateScannedCode } from '../../../utils/validators';
 import { PalletConfirmationModal } from '../../../components/PalletConfirmationModal';
 import ReportIssueModal from '../../../components/ReportIssueModal';
+import { Button } from '../../../components/ui';
 import './RecibirCaja.css';
 
 const RegistrarCaja: React.FC = () => {
@@ -118,15 +119,15 @@ const RegistrarCaja: React.FC = () => {
   return (
     <div className="registrar-caja-content">
       <div className="registrar-caja-header">
-        <button onClick={handleBack} className="back-btn">
+        <Button onClick={handleBack} className="back-btn">
           ← Volver
-        </button>
+        </Button>
         <h1>Recibir Pallets o Cajas</h1>
         <p>Escanea o ingresa el código de caja o pallet para recepción en BODEGA</p>
         
         {/* Toggle Scanner Mode */}
         <div className="scanner-mode-toggle">
-          <button 
+          <Button
             onClick={toggleScanBoxMode}
             className={`toggle-btn ${scanBoxMode ? 'active' : ''}`}
             disabled={loading}
@@ -137,7 +138,7 @@ const RegistrarCaja: React.FC = () => {
             <span className="toggle-text">
               {scanBoxMode ? 'Modo Scanner: ON' : 'Modo Scanner: OFF'}
             </span>
-          </button>
+          </Button>
           {scanBoxMode && (
             <p className="scanner-mode-info">
               🔍 Modo scanner activo - El campo permanecerá enfocado para escaneo consecutivo
@@ -151,7 +152,7 @@ const RegistrarCaja: React.FC = () => {
           <div className="error-message">
             <span className="error-icon">⚠️</span>
             <span className="error-text">{error}</span>
-            <button onClick={reset} className="error-close">✕</button>
+            <Button onClick={reset} className="error-close">✕</Button>
           </div>
         </div>
       )}
@@ -248,30 +249,30 @@ const RegistrarCaja: React.FC = () => {
           <div className="test-codes">
             <p>Códigos de prueba:</p>
             <div className="test-buttons">
-              <button
+              <Button
                 type="button"
                 onClick={() => setCodigo('123456789012345')}
                 className="test-btn"
                 disabled={loading}
               >
                 Caja: 123456789012345
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
                 onClick={() => setCodigo('987654321098765')}
                 className="test-btn"
                 disabled={loading}
               >
                 Caja: 987654321098765
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
                 onClick={() => setCodigo('123456789012')}
                 className="test-btn"
                 disabled={loading}
               >
                 Pallet: 123456789012
-              </button>
+              </Button>
             </div>
           </div>
         </div>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,4 +3,9 @@
 declare module "*.svg" {
   const content: string;
   export default content;
-} 
+}
+
+declare module '*.module.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,12 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
+    /* Path mapping */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+    "rewrites": [
+      { "source": "/(.*)", "destination": "/index.html" }
+    ]
+  }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,10 @@
 {
-    "rewrites": [
-      { "source": "/(.*)", "destination": "/index.html" }
-    ]
-  }
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
 }) 


### PR DESCRIPTION
## Summary
- create global design system with SF Pro and iOS colors
- use the new design system in global styles
- restyle header layout for translucent iOS look
- add fade/scale animation to ReportIssueModal

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6869c2ba5250832d8012945f5ff0d43d